### PR TITLE
chore: remove default build target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-[build]
-target = "xtensa-esp32-espidf"
+# [build]
+# target = "xtensa-esp32-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         action:
           - command: +esp build
-            args: --release
+            args: --release --target xtensa-esp32-espidf
           - command: fmt
             args: --all -- --check --color always
           - command: +esp clippy

--- a/.mise.toml
+++ b/.mise.toml
@@ -31,16 +31,12 @@ run = "cargo test --target $HOST_TARGET"
 
 [tasks.flash]
 description = "Flash to ESP32 (uses esp toolchain)"
-run = "cargo +esp espflash flash --release"
+run = "cargo +esp espflash flash --release --target xtensa-esp32-espidf"
 
 [tasks.build]
 description = "Build for ESP32 (uses esp toolchain)"
-run = "cargo +esp build --release"
+run = "cargo +esp build --release --target xtensa-esp32-espidf"
 
 [tasks.monitor]
 description = "Monitor ESP32 serial output"
 run = "espflash monitor"
-
-[tasks.check-host]
-description = "Show detected host target"
-run = "echo Host target: $HOST_TARGET"


### PR DESCRIPTION
rust-analyzer does not work with the xtensa target as default