### PR TITLE
feat(companion): add scan timeout and retry to ScanView

### DIFF
--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -4,9 +4,32 @@ import Observation
 enum ConnectionState: Equatable {
     case poweredOff
     case scanning
+    case notFound
     case connecting
+    case connectionFailed
     case discoveringServices
+    case setupFailed
     case ready
+}
+
+extension ConnectionState {
+    var isTimeoutable: Bool {
+        switch self {
+        case .scanning, .connecting, .discoveringServices:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isFailure: Bool {
+        switch self {
+        case .notFound, .connectionFailed, .setupFailed:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 @Observable
@@ -81,6 +104,26 @@ class BoardConnection {
         lastCommandResult = nil
         delegate.write(Data([0x00, color.rawValue]), to: GATT.matchControl)
     }
+
+    func restartScanning() {
+        delegate.restartScanning()
+    }
+
+    func connectionTimedOut() {
+        switch connectionState {
+        case .scanning:
+            delegate.stopScanning()
+            connectionState = .notFound
+        case .connecting:
+            delegate.cancelConnection()
+            connectionState = .connectionFailed
+        case .discoveringServices:
+            delegate.cancelConnection()
+            connectionState = .setupFailed
+        default:
+            break
+        }
+    }
 }
 
 private class BLEDelegate: NSObject {
@@ -100,6 +143,27 @@ private class BLEDelegate: NSObject {
     func write(_ data: Data, to uuid: CBUUID) {
         guard let peripheral, let char = characteristics[uuid] else { return }
         peripheral.writeValue(data, for: char, type: .withResponse)
+    }
+
+    func restartScanning() {
+        centralManager.stopScan()
+        peripheral = nil
+        characteristics.removeAll()
+        startScanning()
+    }
+
+    func stopScanning() {
+        centralManager.stopScan()
+    }
+
+    func cancelConnection() {
+        guard let p = peripheral else { return }
+        // Clear state BEFORE asking CoreBluetooth to cancel, guaranteeing
+        // the delegate guards (didDisconnect / didFailToConnect) will see
+        // self.peripheral == nil and bail out.
+        peripheral = nil
+        characteristics.removeAll()
+        centralManager.cancelPeripheralConnection(p)
     }
 
     private func startScanning() {
@@ -150,6 +214,9 @@ extension BLEDelegate: CBCentralManagerDelegate {
         didFailToConnect peripheral: CBPeripheral,
         error: Error?
     ) {
+        // cancelConnection() nils self.peripheral before this callback fires.
+        // If nil, the cancellation was intentional — don't restart scanning.
+        guard self.peripheral != nil else { return }
         startScanning()
     }
 
@@ -158,6 +225,9 @@ extension BLEDelegate: CBCentralManagerDelegate {
         didDisconnectPeripheral peripheral: CBPeripheral,
         error: Error?
     ) {
+        // cancelConnection() nils self.peripheral before this callback fires.
+        // If nil, the disconnect was intentional — don't auto-reconnect.
+        guard self.peripheral != nil else { return }
         characteristics.removeAll()
         awaitingInitialState = false
         owner?.wifiManager.reset()

--- a/companion/ChessBoard/Sources/Views/ScanView.swift
+++ b/companion/ChessBoard/Sources/Views/ScanView.swift
@@ -3,20 +3,72 @@ import SwiftUI
 struct ScanView: View {
     @Environment(BoardConnection.self) private var board
 
+    private let connectionTimeout: Duration = .seconds(20)
+
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
 
-            ProgressView()
-                .controlSize(.large)
+            if board.connectionState.isFailure {
+                Image(systemName: failureIcon)
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
 
-            Text(statusText)
-                .font(.headline)
-                .foregroundStyle(.secondary)
+                Text(failureMessage)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+
+                Button("Retry") {
+                    board.restartScanning()
+                }
+                .buttonStyle(.borderedProminent)
+            } else {
+                ProgressView()
+                    .controlSize(.large)
+
+                Text(statusText)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
 
             Spacer()
         }
         .navigationTitle("ChessBoard")
+        .task(id: board.connectionState) {
+            guard board.connectionState.isTimeoutable else { return }
+            do {
+                try await Task.sleep(for: connectionTimeout)
+                board.connectionTimedOut()
+            } catch {
+                // Task cancelled — state changed before timeout, nothing to do.
+            }
+        }
+    }
+
+    private var failureIcon: String {
+        switch board.connectionState {
+        case .notFound:
+            return "exclamationmark.triangle"
+        case .connectionFailed:
+            return "bolt.horizontal.circle"
+        case .setupFailed:
+            return "gear.badge.xmark"
+        default:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    private var failureMessage: String {
+        switch board.connectionState {
+        case .notFound:
+            return "Board not found"
+        case .connectionFailed:
+            return "Connection failed"
+        case .setupFailed:
+            return "Setup failed"
+        default:
+            return "Something went wrong"
+        }
     }
 
     private var statusText: String {
@@ -25,10 +77,16 @@ struct ScanView: View {
             return "Turn on Bluetooth"
         case .scanning:
             return "Searching for board…"
+        case .notFound:
+            return "Board not found"
         case .connecting:
             return "Connecting…"
+        case .connectionFailed:
+            return "Connection failed"
         case .discoveringServices:
             return "Setting up…"
+        case .setupFailed:
+            return "Setup failed"
         case .ready:
             return "Connected"
         }

--- a/docs/specs/2026-03-31-ble-companion-app-design.md
+++ b/docs/specs/2026-03-31-ble-companion-app-design.md
@@ -258,6 +258,10 @@ SwiftUI + CoreBluetooth. No third-party dependencies.
 
 ```
 Not connected → ScanView (scanning animation, auto-connects on discovery)
+  ├─ Timeout (20s) → failure UI (Retry → restart scan)
+  │   ├─ Scan timeout → "Board not found"
+  │   ├─ Connect timeout → "Connection failed"
+  │   └─ Setup timeout → "Setup failed"
   │
   └─ Connected, idle (0x00) → NewGameView
        ├─ White Player config (type picker + type-specific fields)


### PR DESCRIPTION
## Summary

ScanView previously spun indefinitely when the chess board wasn't reachable via BLE. This adds a 20-second timeout to all pre-ready connection states (scanning, connecting, service discovery), each transitioning to a distinct failure state with a "Retry" button.

| Timeout during | Failure state | Message |
|---|---|---|
| Scanning | `.notFound` | "Board not found" |
| Connecting | `.connectionFailed` | "Connection failed" |
| Service discovery | `.setupFailed` | "Setup failed" |

## References

- Closes #91

## Decisions & callouts

- **20-second timeout** for all states -- long enough for slow BLE, short enough to surface problems.
- **`.task(id: connectionState)`** auto-cancels and restarts the timer on every state transition, so no manual cancellation bookkeeping.
- **Cancellation race condition**: `cancelPeripheralConnection` triggers `didDisconnectPeripheral` or `didFailToConnect`. We clear `peripheral = nil` *before* calling cancel, and both callbacks guard on `self.peripheral != nil` to avoid clobbering the failure state.
- **`isTimeoutable` / `isFailure` computed properties** on `ConnectionState` keep the view logic clean and make it easy to add new states later.

## Manual testing

- [x] Launch app with board powered off -- after ~20s, "Board not found" with warning icon and "Retry" button
- [x] Tap "Retry" -- spinner returns, scanning restarts, timeout resets
- [x] Power on board during scanning -- connects normally before timeout
- [x] Power off board after successful connection -- after ~20s on "Connecting...", shows "Connection failed" with retry
- [x] Tap "Retry" after connection failure, then power on board -- rediscovers and connects