### PR TITLE
fix(companion): read player types from firmware on BLE reconnect

### DIFF
--- a/companion/ChessBoard/Sources/BLE/BLETransport.swift
+++ b/companion/ChessBoard/Sources/BLE/BLETransport.swift
@@ -166,6 +166,12 @@ final class BLETransport: NSObject, BoardTransport,
                 awaitingInitialState = true
                 peripheral.readValue(for: gs)
             }
+            if let wp = characteristics[GATT.whitePlayer] {
+                peripheral.readValue(for: wp)
+            }
+            if let bp = characteristics[GATT.blackPlayer] {
+                peripheral.readValue(for: bp)
+            }
         case GATT.wifiService:
             guard let chars = service.characteristics else { return }
             for char in chars {
@@ -226,6 +232,10 @@ final class BLETransport: NSObject, BoardTransport,
             if let decoded = LichessStatus.decode(data) {
                 owner?.lichessStatus = decoded
             }
+        case GATT.whitePlayer:
+            owner?.whitePlayerType = PlayerType.decode(data)
+        case GATT.blackPlayer:
+            owner?.blackPlayerType = PlayerType.decode(data)
         default:
             break
         }

--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -41,10 +41,10 @@ class BoardConnection {
     var wifiStatus: WifiStatus = .disconnected
     var lichessStatus: LichessStatus = .idle
 
-    /// Player types written by the app when starting a game.
+    /// Player types for each side, read from firmware on connect.
     /// Used to determine which side is human for resign.
-    private(set) var whitePlayerType: PlayerType?
-    private(set) var blackPlayerType: PlayerType?
+    var whitePlayerType: PlayerType?
+    var blackPlayerType: PlayerType?
 
     private var transport: BoardTransport?
 

--- a/companion/ChessBoard/Sources/Models/PlayerType.swift
+++ b/companion/ChessBoard/Sources/Models/PlayerType.swift
@@ -22,4 +22,16 @@ enum PlayerType: UInt8, Equatable {
         case .lichessAi: return Data([0x02, UInt8(level)])
         }
     }
+
+    /// Decode a player type from the firmware wire format.
+    ///
+    /// Wire format:
+    /// - `[0x00]` → `.human`
+    /// - `[0x01]` → `.embedded`
+    /// - `[0x02, level]` → `.lichessAi`
+    /// - `[0xFF]` (UNSET) → `nil`
+    static func decode(_ data: Data) -> PlayerType? {
+        guard let first = data.first else { return nil }
+        return PlayerType(rawValue: first)
+    }
 }

--- a/companion/ChessBoard/Tests/BoardConnectionTests.swift
+++ b/companion/ChessBoard/Tests/BoardConnectionTests.swift
@@ -117,4 +117,33 @@ final class BoardConnectionTests: XCTestCase {
         board.connectionTimedOut()
         XCTAssertEqual(board.connectionState, .setupFailed)
     }
+
+    func testResignColorAfterReconnect() {
+        // Simulate fresh app start: player types are nil, game still in progress on firmware
+        let board = BoardConnection(
+            connectionState: .ready,
+            gameState: GameState(status: .inProgress, turn: .white),
+            whitePlayerType: nil,
+            blackPlayerType: nil
+        )
+        // Before player types are read from firmware: no resign available
+        XCTAssertNil(board.resignColor)
+
+        // Simulate BLE transport reading player types from firmware
+        board.whitePlayerType = .human
+        board.blackPlayerType = .embedded
+
+        // Now resign should work — human is white
+        XCTAssertEqual(board.resignColor, .white)
+    }
+
+    func testResignColorNilWhenPlayersUnset() {
+        let board = BoardConnection(
+            connectionState: .ready,
+            gameState: GameState(status: .inProgress, turn: .white),
+            whitePlayerType: nil,
+            blackPlayerType: nil
+        )
+        XCTAssertNil(board.resignColor)
+    }
 }

--- a/companion/ChessBoard/Tests/PlayerTypeTests.swift
+++ b/companion/ChessBoard/Tests/PlayerTypeTests.swift
@@ -37,4 +37,24 @@ final class PlayerTypeTests: XCTestCase {
             Data([0x02, 0x04])
         )
     }
+
+    func testDecodeHuman() {
+        XCTAssertEqual(PlayerType.decode(Data([0x00])), .human)
+    }
+
+    func testDecodeEmbedded() {
+        XCTAssertEqual(PlayerType.decode(Data([0x01])), .embedded)
+    }
+
+    func testDecodeLichessAi() {
+        XCTAssertEqual(PlayerType.decode(Data([0x02, 4])), .lichessAi)
+    }
+
+    func testDecodeUnset() {
+        XCTAssertNil(PlayerType.decode(Data([0xFF])))
+    }
+
+    func testDecodeEmpty() {
+        XCTAssertNil(PlayerType.decode(Data()))
+    }
 }

--- a/docs/specs/2026-03-31-ble-companion-app-design.md
+++ b/docs/specs/2026-03-31-ble-companion-app-design.md
@@ -288,7 +288,7 @@ A single `BoardConnection` class wraps CoreBluetooth and exposes observable stat
 
 ### Reconnection
 
-If BLE disconnects, the app re-initiates connection from the `didDisconnectPeripheral` delegate callback by calling `centralManager.connect` again. On reconnect, the app reads current Game State, WiFi Status, and Lichess Status. The firmware retains WiFi and Lichess status across BLE reconnections (only Command Result is reset on reconnect). Navigation is driven reactively by the observable `gameState` — once `connectionState` reaches `.ready`, `ContentView` displays `NewGameView` when status is idle (0x00), or `ActiveGameView` for any other status (0x01–0x06). No explicit navigation action is required on reconnect.
+If BLE disconnects, the app re-initiates connection from the `didDisconnectPeripheral` delegate callback by calling `centralManager.connect` again. On reconnect, the app reads current Game State, White Player, Black Player, WiFi Status, and Lichess Status. The firmware retains WiFi and Lichess status across BLE reconnections (only Command Result is reset on reconnect). Navigation is driven reactively by the observable `gameState` — once `connectionState` reaches `.ready`, `ContentView` displays `NewGameView` when status is idle (0x00), or `ActiveGameView` for any other status (0x01–0x06). No explicit navigation action is required on reconnect.
 
 If WiFi drops during an active Lichess game, the board's Lichess connection breaks and the game ends via the board's game state transition (the firmware moves to a terminal status). The app surfaces this through the existing Game State notification path — no WiFi-specific UI is needed in ActiveGameView.
 


### PR DESCRIPTION
## Summary

After a BLE disconnect + reconnect (or app process restart), the companion app lost knowledge of which colors are human vs computer, causing the resign button to disappear from the active game view. The root cause was that `whitePlayerType`/`blackPlayerType` on `BoardConnection` were only set locally by `configureAndStart()` and never re-read from firmware.

The fix reads the `whitePlayer` and `blackPlayer` BLE characteristics from the firmware during service discovery on every connect/reconnect. The firmware already exposed these as readable characteristics that retain their values during a game and reset to `0xFF` (unset) when no game is active — no firmware changes needed.

## Decisions & callouts

- `PlayerType.decode(_:)` does not validate payload length for Lichess AI (`[0x02, level]`) — it only checks the first byte. This is intentional since `PlayerType` doesn't carry the level value (same pattern as the existing encode API), and the data comes from firmware-controlled characteristics.
- `whitePlayerType`/`blackPlayerType` changed from `private(set)` to plain `var` to allow `BLETransport` (a different file in the same module) to set them. This matches the pattern used by all other `BoardConnection` properties (`connectionState`, `gameState`, `wifiStatus`, `lichessStatus`).

## Manual testing

- [x] Start a game (human vs engine), force-quit the app, relaunch — the resign button should appear once BLE reconnects and the game view loads
- [x] Start a game, toggle Bluetooth off/on in Control Center — after reconnection the resign button should reappear
- [x] When no game is active (idle state), reconnect — verify no crash or unexpected UI from reading unset (`0xFF`) player characteristics