### PR TITLE
Add board_api module with transport-agnostic domain types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ PieceSensor::read_positions() → ByColor<Bitboard>
 - **player/human.rs** — `HumanPlayer`: detects moves from sensor bitboards by matching against legal moves
 - **player/embedded.rs** — `EmbeddedEngine`: heuristic AI (captures > castling > promotions > random)
 - **feedback.rs** — `compute_feedback` and `compute_state_feedback`: feedback from position + sensors. Recovery guidance is integrated as a fallback path.
-- **session.rs** — `GameSession`: owns chess position + two `Box<dyn Player>`, produces `TickResult` per sensor frame; also exposes `resign()`, `is_game_over()`, and `game_state()` for BLE game lifecycle management
+- **board_api.rs** — Transport-agnostic domain types from `docs/board-api.md`: `GameStatus`, `PlayerType`, `BoardApiError`. `GameSession` returns these directly; BLE encoding lives in `ble_protocol`.
+- **session.rs** — `GameSession`: owns chess position + two `Box<dyn Player>`, produces `TickResult` per sensor frame; also exposes `resign()`, `is_game_over()`, and `game_state()` for game lifecycle management
 - **ble_protocol.rs** — `BleCommand`, `PlayerConfig`, `GameState`, `CommandResult`, `WifiAuthMode`, `WifiConfig`, `WifiState`, `WifiStatus`, `LichessState`, `LichessStatus`, UUID constants, binary encoding/decoding. Platform-independent, host-testable.
 - **esp32/sensor.rs** — `Esp32PieceSensor`: ADC + mux scanning, `RawScan` for raw millivolt readings, `read_raw()` primitive
 - **esp32/ble.rs** — `start_ble()` initializes NimBLE and returns `BleCommands` (command receiver) + `BleNotifier` (characteristic updater). Three fully functional GATT services (WiFi, Lichess, Game), typed characteristic handles.

--- a/src/board_api.rs
+++ b/src/board_api.rs
@@ -1,0 +1,165 @@
+use shakmaty::Color;
+
+/// The game lifecycle state.
+///
+/// Defined in `docs/board-api.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GameStatus {
+    /// No game in progress.
+    Idle,
+    /// Waiting for starting position on sensors.
+    AwaitingPieces,
+    /// Game is actively being played.
+    InProgress,
+    /// Game ended by checkmate.
+    Checkmate { loser: Color },
+    /// Game ended by stalemate.
+    Stalemate,
+    /// A player resigned.
+    Resigned { color: Color },
+}
+
+impl GameStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            GameStatus::Checkmate { .. } | GameStatus::Stalemate | GameStatus::Resigned { .. }
+        )
+    }
+}
+
+/// Determines how moves arrive for a given side.
+///
+/// Defined in `docs/board-api.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlayerType {
+    /// Detected from sensors on the physical board.
+    Human,
+    /// Delivered via SubmitMove.
+    Remote,
+}
+
+/// Typed errors for Board API operations.
+///
+/// Defined in `docs/board-api.md`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BoardApiError {
+    #[error("game already in progress")]
+    GameAlreadyInProgress,
+    #[error("no game in progress")]
+    NoGameInProgress,
+    #[error("not your turn")]
+    NotYourTurn,
+    #[error("illegal move")]
+    IllegalMove,
+    #[error("cannot resign for remote player")]
+    CannotResignForRemotePlayer,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shakmaty::Color;
+
+    #[test]
+    fn idle_is_not_terminal() {
+        assert!(!GameStatus::Idle.is_terminal());
+    }
+
+    #[test]
+    fn awaiting_pieces_is_not_terminal() {
+        assert!(!GameStatus::AwaitingPieces.is_terminal());
+    }
+
+    #[test]
+    fn in_progress_is_not_terminal() {
+        assert!(!GameStatus::InProgress.is_terminal());
+    }
+
+    #[test]
+    fn checkmate_is_terminal() {
+        assert!(
+            GameStatus::Checkmate {
+                loser: Color::White
+            }
+            .is_terminal()
+        );
+    }
+
+    #[test]
+    fn stalemate_is_terminal() {
+        assert!(GameStatus::Stalemate.is_terminal());
+    }
+
+    #[test]
+    fn resigned_is_terminal() {
+        assert!(
+            GameStatus::Resigned {
+                color: Color::Black
+            }
+            .is_terminal()
+        );
+    }
+
+    #[test]
+    fn checkmate_carries_loser() {
+        let status = GameStatus::Checkmate {
+            loser: Color::Black,
+        };
+        assert_eq!(
+            status,
+            GameStatus::Checkmate {
+                loser: Color::Black
+            }
+        );
+        assert_ne!(
+            status,
+            GameStatus::Checkmate {
+                loser: Color::White
+            }
+        );
+    }
+
+    #[test]
+    fn resigned_carries_color() {
+        let status = GameStatus::Resigned {
+            color: Color::White,
+        };
+        assert_eq!(
+            status,
+            GameStatus::Resigned {
+                color: Color::White
+            }
+        );
+        assert_ne!(
+            status,
+            GameStatus::Resigned {
+                color: Color::Black
+            }
+        );
+    }
+
+    #[test]
+    fn player_type_debug() {
+        assert_eq!(format!("{:?}", PlayerType::Human), "Human");
+        assert_eq!(format!("{:?}", PlayerType::Remote), "Remote");
+    }
+
+    #[test]
+    fn board_api_error_display() {
+        assert_eq!(
+            BoardApiError::GameAlreadyInProgress.to_string(),
+            "game already in progress"
+        );
+        assert_eq!(
+            BoardApiError::NoGameInProgress.to_string(),
+            "no game in progress"
+        );
+        assert_eq!(BoardApiError::NotYourTurn.to_string(), "not your turn");
+        assert_eq!(BoardApiError::IllegalMove.to_string(), "illegal move");
+        assert_eq!(
+            BoardApiError::CannotResignForRemotePlayer.to_string(),
+            "cannot resign for remote player"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use shakmaty::{Bitboard, ByColor};
 
 pub mod ble_protocol;
+pub mod board_api;
 pub mod feedback;
 pub mod lichess;
 pub mod player;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,13 @@ fn main() {
     use shakmaty::{Color, Position};
     use unnamed_chess_project::ble_protocol::{
         BleCommand, CommandResult, CommandSource, GameState, GameStatus, LichessStatus,
-        PlayerConfig, WifiAuthMode, WifiStatus, UNSET_BYTE,
+        PlayerConfig, UNSET_BYTE, WifiAuthMode, WifiStatus,
     };
     use unnamed_chess_project::esp32::config::{LedPalette, SensorCalibration, SensorConfig};
     use unnamed_chess_project::esp32::{
-        start_ble, Esp32LedDisplay, Esp32LichessClient, Esp32PieceSensor, WifiConnection,
+        Esp32LedDisplay, Esp32LichessClient, Esp32PieceSensor, WifiConnection, start_ble,
     };
-    use unnamed_chess_project::lichess::{spawn_lichess_opponent, LichessConfig};
+    use unnamed_chess_project::lichess::{LichessConfig, spawn_lichess_opponent};
     use unnamed_chess_project::session::GameSession;
     use unnamed_chess_project::{BoardDisplay, PieceSensor};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,16 @@ fn main() {
     use esp_idf_svc::hal::peripherals::Peripherals;
     use esp_idf_svc::nvs::{EspDefaultNvsPartition, EspNvsPartition, NvsCustom};
     use esp_idf_svc::wifi::AuthMethod;
-    use shakmaty::Color;
+    use shakmaty::{Color, Position};
     use unnamed_chess_project::ble_protocol::{
         BleCommand, CommandResult, CommandSource, GameState, GameStatus, LichessStatus,
-        PlayerConfig, UNSET_BYTE, WifiAuthMode, WifiStatus,
+        PlayerConfig, WifiAuthMode, WifiStatus, UNSET_BYTE,
     };
     use unnamed_chess_project::esp32::config::{LedPalette, SensorCalibration, SensorConfig};
     use unnamed_chess_project::esp32::{
-        Esp32LedDisplay, Esp32LichessClient, Esp32PieceSensor, WifiConnection, start_ble,
+        start_ble, Esp32LedDisplay, Esp32LichessClient, Esp32PieceSensor, WifiConnection,
     };
-    use unnamed_chess_project::lichess::{LichessConfig, spawn_lichess_opponent};
+    use unnamed_chess_project::lichess::{spawn_lichess_opponent, LichessConfig};
     use unnamed_chess_project::session::GameSession;
     use unnamed_chess_project::{BoardDisplay, PieceSensor};
 
@@ -253,9 +253,10 @@ fn main() {
                         };
 
                     let new_session = GameSession::new(white_player, black_player);
-                    let state = new_session.game_state();
-                    notifier.notify_game_state(&state);
-                    prev_game_state = Some(state);
+                    let status = new_session.game_state();
+                    let ble_state = to_ble_game_state(&status, new_session.position().turn());
+                    notifier.notify_game_state(&ble_state);
+                    prev_game_state = Some(ble_state);
 
                     session = Some(new_session);
                     prev_positions = Some(initial_positions);
@@ -266,12 +267,13 @@ fn main() {
                     if let Some(ref mut s) = session {
                         if s.resign(color) {
                             log::info!("{color:?} resigns");
-                            let state = s.game_state();
+                            let status = s.game_state();
+                            let ble_state = to_ble_game_state(&status, s.position().turn());
                             notifier.notify_command_result(&CommandResult::success(
                                 CommandSource::MatchControl,
                             ));
-                            notifier.notify_game_state(&state);
-                            prev_game_state = Some(state);
+                            notifier.notify_game_state(&ble_state);
+                            prev_game_state = Some(ble_state);
                         } else {
                             log::warn!("Resign rejected for {color:?}");
                             notifier.notify_command_result(&CommandResult::error(
@@ -355,16 +357,17 @@ fn main() {
                 log::warn!("LED update failed: {e}");
             }
 
-            let current_state = s.game_state();
-            let state_changed = prev_game_state.as_ref() != Some(&current_state);
+            let current_status = s.game_state();
+            let current_ble_state = to_ble_game_state(&current_status, s.position().turn());
+            let state_changed = prev_game_state.as_ref() != Some(&current_ble_state);
             if state_changed {
-                notifier.notify_game_state(&current_state);
-                prev_game_state = Some(current_state);
+                notifier.notify_game_state(&current_ble_state);
+                prev_game_state = Some(current_ble_state);
             }
 
             if s.is_game_over() {
-                let final_state = s.game_state();
-                log::info!("Game over: {:?}", final_state.status);
+                let final_status = s.game_state();
+                log::info!("Game over: {:?}", final_status);
 
                 session = None;
                 white_config = None;
@@ -378,6 +381,28 @@ fn main() {
         }
 
         FreeRtos::delay_ms(50);
+    }
+}
+
+#[cfg(target_os = "espidf")]
+fn to_ble_game_state(
+    status: &unnamed_chess_project::board_api::GameStatus,
+    turn: shakmaty::Color,
+) -> unnamed_chess_project::ble_protocol::GameState {
+    use unnamed_chess_project::ble_protocol::{GameState, GameStatus as BleGameStatus};
+    use unnamed_chess_project::board_api::GameStatus;
+
+    let ble_status = match status {
+        GameStatus::Idle => BleGameStatus::Idle,
+        GameStatus::AwaitingPieces => BleGameStatus::AwaitingPieces,
+        GameStatus::InProgress => BleGameStatus::InProgress,
+        GameStatus::Checkmate { .. } => BleGameStatus::Checkmate,
+        GameStatus::Stalemate => BleGameStatus::Stalemate,
+        GameStatus::Resigned { .. } => BleGameStatus::Resignation,
+    };
+    GameState {
+        status: ble_status,
+        turn,
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use shakmaty::{Bitboard, ByColor, Chess, Color, Move, Position};
 
 use crate::board_api::GameStatus;
-use crate::feedback::{BoardFeedback, StatusKind, compute_feedback, compute_state_feedback};
+use crate::feedback::{compute_feedback, compute_state_feedback, BoardFeedback, StatusKind};
 use crate::player::{GameAction, Player, PlayerStatus};
 
 #[derive(Debug, Clone)]
@@ -67,7 +67,7 @@ impl GameSession {
     }
 
     pub fn is_game_over(&self) -> bool {
-        self.resigned.is_some() || self.position.legal_moves().is_empty()
+        self.game_state().is_terminal()
     }
 
     pub fn game_state(&self) -> GameStatus {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
 use shakmaty::{Bitboard, ByColor, Chess, Color, Move, Position};
 
-use crate::ble_protocol::{GameState, GameStatus};
+use crate::board_api::GameStatus;
 use crate::feedback::{BoardFeedback, StatusKind, compute_feedback, compute_state_feedback};
 use crate::player::{GameAction, Player, PlayerStatus};
 
@@ -70,23 +70,22 @@ impl GameSession {
         self.resigned.is_some() || self.position.legal_moves().is_empty()
     }
 
-    pub fn game_state(&self) -> GameState {
+    pub fn game_state(&self) -> GameStatus {
+        if let Some(color) = self.resigned {
+            return GameStatus::Resigned { color };
+        }
         let legal_moves = self.position.legal_moves();
-        let status = if self.resigned.is_some() {
-            GameStatus::Resignation
-        } else if legal_moves.is_empty() {
+        if legal_moves.is_empty() {
             if self.position.is_check() {
-                GameStatus::Checkmate
+                GameStatus::Checkmate {
+                    loser: self.position.turn(),
+                }
             } else {
                 GameStatus::Stalemate
             }
         } else {
             GameStatus::InProgress
-        };
-
-        let turn = self.position.turn();
-
-        GameState { status, turn }
+        }
     }
 
     pub fn tick(&mut self, sensors: ByColor<Bitboard>) -> TickResult {
@@ -575,26 +574,28 @@ mod tests {
 
     #[test]
     fn game_state_in_progress_for_new_session() {
-        use crate::ble_protocol::GameStatus;
+        use crate::board_api::GameStatus;
 
         let (_sensor, session) = human_vs_human();
         let state = session.game_state();
 
-        assert_eq!(state.status, GameStatus::InProgress);
-        assert_eq!(state.turn, Color::White);
+        assert_eq!(state, GameStatus::InProgress);
     }
 
     #[test]
     fn game_state_resignation_after_resign() {
-        use crate::ble_protocol::GameStatus;
+        use crate::board_api::GameStatus;
 
         let (_sensor, mut session) = human_vs_human();
         assert!(session.resign(Color::Black));
 
         let state = session.game_state();
-        assert_eq!(state.status, GameStatus::Resignation);
-        // Turn should still reflect the current (unmodified) position.
-        assert_eq!(state.turn, Color::White);
+        assert_eq!(
+            state,
+            GameStatus::Resigned {
+                color: Color::Black
+            }
+        );
     }
 
     #[test]
@@ -645,7 +646,7 @@ mod tests {
 
     #[test]
     fn game_state_checkmate() {
-        use crate::ble_protocol::GameStatus;
+        use crate::board_api::GameStatus;
 
         // Fool's mate: white is checkmated
         let fen = "rnb1kbnr/pppp1ppp/4p3/8/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3";
@@ -672,20 +673,17 @@ mod tests {
         );
         let state = session.game_state();
         assert_eq!(
-            state.status,
-            GameStatus::Checkmate,
-            "game_state should report Checkmate status"
-        );
-        assert_eq!(
-            state.turn,
-            Color::White,
-            "turn should be white (checkmated side)"
+            state,
+            GameStatus::Checkmate {
+                loser: Color::White
+            },
+            "game_state should report Checkmate with white as loser"
         );
     }
 
     #[test]
     fn game_state_stalemate() {
-        use crate::ble_protocol::GameStatus;
+        use crate::board_api::GameStatus;
 
         // Classic stalemate: black king trapped, no legal moves, not in check
         let fen = "7k/5Q2/6K1/8/8/8/8/8 b - - 0 1";
@@ -721,14 +719,9 @@ mod tests {
         );
         let state = session.game_state();
         assert_eq!(
-            state.status,
+            state,
             GameStatus::Stalemate,
             "game_state should report Stalemate status"
-        );
-        assert_eq!(
-            state.turn,
-            Color::Black,
-            "turn should be black (stalemated side)"
         );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use shakmaty::{Bitboard, ByColor, Chess, Color, Move, Position};
 
 use crate::board_api::GameStatus;
-use crate::feedback::{compute_feedback, compute_state_feedback, BoardFeedback, StatusKind};
+use crate::feedback::{BoardFeedback, StatusKind, compute_feedback, compute_state_feedback};
 use crate::player::{GameAction, Player, PlayerStatus};
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Introduces `board_api.rs` as the canonical home for Board API domain types (`GameStatus`, `PlayerType`, `BoardApiError`), decoupling `GameSession` from BLE wire encoding. `session.rs` now returns `board_api::GameStatus` directly, and a temporary `to_ble_game_state()` adapter in `main.rs` bridges to the existing BLE protocol until the BLE layer is rewritten.

## References

- Spec: `docs/board-api.md`
- ADR: `docs/adrs/0001-separate-board-firmware-from-client-responsibilities.md`

## Decisions & callouts

- **`to_ble_game_state()` is intentionally lossy** — `Checkmate { loser }` and `Resigned { color }` lose their payload when mapped to the flat BLE `GameStatus` enum. This is expected; the BLE protocol will be updated in a future PR.
- **`is_game_over()` now delegates to `game_state().is_terminal()`**, which recomputes legal moves. The tick loop in `main.rs` may call both `game_state()` and `is_game_over()` in the same iteration. This is a minor optimization opportunity for a follow-up, not a correctness issue.