### PR TITLE
refactor: non-blocking AwaitingPieces + CancelGame support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,16 +66,19 @@ Gate hardware-specific code with `#[cfg(target_os = "espidf")]`. Never mix impor
 
 ```
 BleCommands (mpsc channel) → BleCommand
-    → main.rs drains commands each tick (start game, resign, query state)
+    → main.rs orchestrates BoardState state machine: Idle → AwaitingPieces → InProgress
+    → BLE commands are drained each tick regardless of state
+    → In AwaitingPieces, sensors are checked non-blockingly for starting position
+    → session.tick() is only called in InProgress state
     → BleNotifier pushes state back to characteristics
 PieceSensor::read_positions() → ByColor<Bitboard>
-    → GameSession::tick(sensors) → TickResult
+    → GameSession::tick(sensors) → TickResult (only when InProgress)
         → Player::poll_move() detects/computes move
         → compute_feedback(position, sensors, reference_sensors) → BoardFeedback
             → BoardDisplay::show(&feedback)
 ```
 
-**GameSession** (`session.rs`) orchestrates the per-tick sequence: poll active player → apply move → notify opponent → compute feedback. `main.rs` also drains `BleCommand`s from the BLE server each tick before calling `session.tick()`.
+**GameSession** (`session.rs`) orchestrates the per-tick sequence: poll active player → apply move → notify opponent → compute feedback. `main.rs` also manages the `BoardState` state machine: transitions from Idle (no game) to AwaitingPieces (waiting for start position setup) to InProgress (game is active). BLE commands are drained every tick regardless of state.
 
 ### Key Abstractions
 

--- a/docs/specs/2026-03-31-ble-companion-app-design.md
+++ b/docs/specs/2026-03-31-ble-companion-app-design.md
@@ -82,15 +82,16 @@ Game lifecycle and state. The core of the protocol (UUID prefix 1xxx).
 | White Player       | Read, Write  | Tagged binary: type byte + type-specific config (see below)  |
 | Black Player       | Read, Write  | Same format as White Player                                  |
 | Start Game         | Write        | Empty (trigger)                                              |
-| Match Control      | Write        | Action (u8: 0x00=resign), player (u8: 0x00=white, 0x01=black) |
+| Match Control      | Write        | Action-based variable-length payload (see Match Control action format below) |
 | Game State         | Read, Notify | Status (u8), turn (u8: 0x00=white, 0x01=black). Both fields are always present regardless of game status. The `turn` field reflects the side to move — it is not reinterpreted based on game outcome. In checkmate/stalemate this is the checkmated/stalemated side; in resignation/draw it is whoever's turn it was when the game ended. |
 | Command Result     | Read, Notify | Status code (u8: 0x00=ok, 0x01=error), command source (u8: 0x00=StartGame, 0x01=MatchControl), error message (length-prefixed string, empty if ok) |
 
-**Match Control action values:**
+**Match Control action values and payload format:**
 
-| Value | Action           |
-| ----- | ---------------- |
-| 0x00  | Resign           |
+| Value | Action          | Payload Format       |
+| ----- | --------------- | -------------------- |
+| 0x00  | Resign          | `[0x00, color: u8]` where color is `0x00`=white, `0x01`=black |
+| 0x01  | Cancel Game     | `[0x01]` (no additional bytes) |
 
 **Command source values:**
 
@@ -106,7 +107,9 @@ Game lifecycle and state. The core of the protocol (UUID prefix 1xxx).
 **Command Result behavior:** Every write to Start Game or Match Control produces a Command Result notification — `[0x00, source, 0x00]` on success, `[0x01, source, msg_len, msg...]` on failure. The `source` byte echoes which command produced the result, allowing the app to correlate responses without tracking state. Error conditions include:
 - Start Game written before both players are configured (either still reads `0xFF`)
 - Start Game written while a game is already in progress
-- Match Control written when no game is in progress
+- Match Control (Resign) written when no game is in progress
+- Match Control (CancelGame) written when no game is in progress → error "no game in progress"
+- Match Control (CancelGame) in AwaitingPieces or InProgress state → success, resets board to Idle
 - Lichess AI level out of range (must be 1–8)
 - Unrecognized action or player type values
 
@@ -163,6 +166,13 @@ App writes Start Game    → (empty)
 App writes Match Control → [0x00] [0x00]                 (resign, white)
 Board notifies Command Result → [0x00] [0x01] [0x00]     (ok, MatchControl, no message)
 Board notifies Game State → [0x05] ...                  (resignation)
+```
+
+**Cancelling a game:**
+```
+App writes Match Control → [0x01]                        (cancel game)
+Board notifies Command Result → [0x00] [0x01] [0x00]     (ok, MatchControl, no message)
+Board notifies Game State → [0x00] ...                  (idle)
 ```
 
 

--- a/src/ble_protocol.rs
+++ b/src/ble_protocol.rs
@@ -123,6 +123,7 @@ pub enum BleCommand {
     SetWhitePlayer(PlayerConfig),
     SetBlackPlayer(PlayerConfig),
     StartGame,
+    CancelGame,
     Resign { color: Color },
     ConfigureWifi(WifiConfig),
     SetLichessToken(String),

--- a/src/ble_protocol.rs
+++ b/src/ble_protocol.rs
@@ -132,20 +132,27 @@ pub enum BleCommand {
 impl BleCommand {
     /// Parse a Match Control characteristic write.
     ///
-    /// Format: `[action: u8, player: u8]`
-    /// - action `0x00` = resign
-    /// - player `0x00` = white, `0x01` = black
+    /// Format: `[action: u8, ...]`
+    /// - action `0x00` = resign → `[0x00, color: u8]`
+    /// - action `0x01` = cancel game → `[0x01]`
     pub fn parse_match_control(bytes: &[u8]) -> Result<Self, ProtocolError> {
-        if bytes.len() < 2 {
-            return Err(ProtocolError::InsufficientData {
-                needed: 2,
-                got: bytes.len(),
-            });
+        if bytes.is_empty() {
+            return Err(ProtocolError::InsufficientData { needed: 1, got: 0 });
         }
         let action = bytes[0];
-        let color = parse_color(bytes[1])?;
         match action {
-            0x00 => Ok(BleCommand::Resign { color }),
+            0x00 => {
+                // Resign: [0x00, color: u8]
+                if bytes.len() < 2 {
+                    return Err(ProtocolError::InsufficientData {
+                        needed: 2,
+                        got: bytes.len(),
+                    });
+                }
+                let color = parse_color(bytes[1])?;
+                Ok(BleCommand::Resign { color })
+            }
+            0x01 => Ok(BleCommand::CancelGame),
             other => Err(ProtocolError::UnknownAction(other)),
         }
     }
@@ -660,9 +667,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_cancel_game() {
+        let result = BleCommand::parse_match_control(&[0x01]);
+        assert_eq!(result, Ok(BleCommand::CancelGame));
+    }
+
+    #[test]
+    fn parse_cancel_game_with_extra_bytes() {
+        // Extra bytes after action byte should be ignored
+        let result = BleCommand::parse_match_control(&[0x01, 0xFF]);
+        assert_eq!(result, Ok(BleCommand::CancelGame));
+    }
+
+    #[test]
     fn reject_unknown_action() {
-        let result = BleCommand::parse_match_control(&[0x01, 0x00]);
-        assert!(matches!(result, Err(ProtocolError::UnknownAction(0x01))));
+        let result = BleCommand::parse_match_control(&[0x02, 0x00]);
+        assert!(matches!(result, Err(ProtocolError::UnknownAction(0x02))));
     }
 
     #[test]
@@ -685,7 +705,7 @@ mod tests {
         let result = BleCommand::parse_match_control(&[]);
         assert!(matches!(
             result,
-            Err(ProtocolError::InsufficientData { needed: 2, got: 0 })
+            Err(ProtocolError::InsufficientData { needed: 1, got: 0 })
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,16 @@
 #[cfg(target_os = "espidf")]
+enum BoardState {
+    Idle,
+    AwaitingPieces {
+        white_config: unnamed_chess_project::ble_protocol::PlayerConfig,
+        black_config: unnamed_chess_project::ble_protocol::PlayerConfig,
+    },
+    InProgress {
+        session: unnamed_chess_project::session::GameSession,
+    },
+}
+
+#[cfg(target_os = "espidf")]
 fn main() {
     use esp_idf_svc::hal::adc::oneshot::AdcDriver;
     use esp_idf_svc::hal::delay::FreeRtos;
@@ -9,8 +21,9 @@ fn main() {
         BleCommand, CommandResult, CommandSource, GameState, GameStatus, PlayerConfig, UNSET_BYTE,
     };
     use unnamed_chess_project::esp32::config::{LedPalette, SensorCalibration, SensorConfig};
-    use unnamed_chess_project::esp32::{Esp32LedDisplay, Esp32PieceSensor, start_ble};
-    use unnamed_chess_project::session::GameSession;
+    use unnamed_chess_project::esp32::{start_ble, Esp32LedDisplay, Esp32PieceSensor};
+    use unnamed_chess_project::feedback::BoardFeedback;
+    use unnamed_chess_project::setup::setup_feedback;
     use unnamed_chess_project::{BoardDisplay, PieceSensor};
 
     esp_idf_svc::sys::link_patches();
@@ -66,7 +79,7 @@ fn main() {
 
     let mut white_config: Option<PlayerConfig> = None;
     let mut black_config: Option<PlayerConfig> = None;
-    let mut session: Option<GameSession> = None;
+    let mut board_state = BoardState::Idle;
     let mut prev_positions = None;
     let mut prev_game_state: Option<GameState> = None;
 
@@ -88,7 +101,7 @@ fn main() {
                     black_config = Some(config);
                 }
                 BleCommand::StartGame => {
-                    if session.is_some() {
+                    if !matches!(board_state, BoardState::Idle) {
                         log::warn!("StartGame received while game is active");
                         notifier.notify_command_result(&CommandResult::error(
                             CommandSource::StartGame,
@@ -106,8 +119,6 @@ fn main() {
                         continue;
                     };
 
-                    // Acknowledge the command and notify AwaitingPieces before
-                    // entering the blocking setup loop.
                     notifier
                         .notify_command_result(&CommandResult::success(CommandSource::StartGame));
                     let awaiting_state = GameState {
@@ -115,51 +126,45 @@ fn main() {
                         turn: Color::White,
                     };
                     notifier.notify_game_state(&awaiting_state);
-
+                    board_state = BoardState::AwaitingPieces {
+                        white_config: w_config.clone(),
+                        black_config: b_config.clone(),
+                    };
                     log::info!("Waiting for starting position...");
-                    let initial_positions =
-                        match wait_for_starting_position(&mut sensor, &mut display) {
-                            Ok(p) => p,
-                            Err(e) => {
-                                log::error!("Initial sensor read failed: {e}");
-                                // Reset to Idle since setup failed.
-                                let idle_state = GameState::idle();
-                                notifier.notify_command_result(&CommandResult::error(
-                                    CommandSource::StartGame,
-                                    "sensor read failed",
-                                ));
-                                notifier.notify_game_state(&idle_state);
-                                prev_game_state = Some(idle_state);
-                                continue;
-                            }
-                        };
-                    log::info!("Starting position detected");
-
-                    let white_player = create_player(w_config, initial_positions);
-                    let black_player = create_player(b_config, initial_positions);
-
-                    let new_session = GameSession::new(white_player, black_player);
-                    let status = new_session.game_state();
-                    let ble_state = to_ble_game_state(&status, new_session.position().turn());
-                    notifier.notify_game_state(&ble_state);
-                    prev_game_state = Some(ble_state);
-
-                    session = Some(new_session);
-                    prev_positions = Some(initial_positions);
-
-                    log::info!("Game started");
                 }
+                BleCommand::CancelGame => match board_state {
+                    BoardState::Idle => {
+                        notifier.notify_command_result(&CommandResult::error(
+                            CommandSource::MatchControl,
+                            "no game in progress",
+                        ));
+                    }
+                    _ => {
+                        board_state = BoardState::Idle;
+                        white_config = None;
+                        black_config = None;
+                        prev_positions = None;
+                        prev_game_state = None;
+                        notifier.notify_command_result(&CommandResult::success(
+                            CommandSource::MatchControl,
+                        ));
+                        notifier.notify_game_state(&GameState::idle());
+                        notifier.update_player_config(Color::White, &[UNSET_BYTE]);
+                        notifier.update_player_config(Color::Black, &[UNSET_BYTE]);
+                        log::info!("Game cancelled");
+                    }
+                },
                 BleCommand::Resign { color } => {
-                    if let Some(ref mut s) = session {
-                        if s.resign(color) {
+                    if let BoardState::InProgress { ref mut session } = board_state {
+                        if session.resign(color) {
                             log::info!("{color:?} resigns");
-                            let status = s.game_state();
-                            let ble_state = to_ble_game_state(&status, s.position().turn());
+                            let state =
+                                to_ble_game_state(&session.game_state(), session.position().turn());
                             notifier.notify_command_result(&CommandResult::success(
                                 CommandSource::MatchControl,
                             ));
-                            notifier.notify_game_state(&ble_state);
-                            prev_game_state = Some(ble_state);
+                            notifier.notify_game_state(&state);
+                            prev_game_state = Some(state);
                         } else {
                             log::warn!("Resign rejected for {color:?}");
                             notifier.notify_command_result(&CommandResult::error(
@@ -181,7 +186,59 @@ fn main() {
             }
         }
 
-        if let Some(ref mut s) = session {
+        if let BoardState::AwaitingPieces {
+            ref white_config,
+            ref black_config,
+        } = board_state
+        {
+            let positions = match sensor.read_positions() {
+                Ok(p) => p,
+                Err(e) => {
+                    log::warn!("Sensor read failed: {e}");
+                    FreeRtos::delay_ms(100);
+                    continue;
+                }
+            };
+            match setup_feedback(&positions) {
+                Some(fb) => {
+                    if let Err(e) = display.show(&fb) {
+                        log::warn!("LED update failed: {e}");
+                    }
+                }
+                None => {
+                    // Starting position detected — create session
+                    if let Err(e) = display.show(&BoardFeedback::default()) {
+                        log::warn!("LED clear failed: {e}");
+                    }
+                    let initial = match sensor.read_positions() {
+                        Ok(p) => p,
+                        Err(e) => {
+                            log::error!("Initial sensor read failed: {e}");
+                            board_state = BoardState::Idle;
+                            notifier.notify_game_state(&GameState::idle());
+                            continue;
+                        }
+                    };
+                    let white_player = create_player(white_config, initial);
+                    let black_player = create_player(black_config, initial);
+                    let new_session = unnamed_chess_project::session::GameSession::new(
+                        white_player,
+                        black_player,
+                    );
+                    let state =
+                        to_ble_game_state(&new_session.game_state(), new_session.position().turn());
+                    notifier.notify_game_state(&state);
+                    prev_game_state = Some(state);
+                    prev_positions = Some(initial);
+                    board_state = BoardState::InProgress {
+                        session: new_session,
+                    };
+                    log::info!("Starting position detected, game started");
+                }
+            }
+        }
+
+        if let BoardState::InProgress { ref mut session } = board_state {
             let positions = match sensor.read_positions() {
                 Ok(p) => p,
                 Err(e) => {
@@ -194,7 +251,7 @@ fn main() {
             log_sensor_changes(prev_positions, positions);
             prev_positions = Some(positions);
 
-            let result = s.tick(positions);
+            let result = session.tick(positions);
 
             if let Some(mv) = &result.last_move {
                 log::info!("Move played: {mv}");
@@ -204,19 +261,19 @@ fn main() {
                 log::warn!("LED update failed: {e}");
             }
 
-            let current_status = s.game_state();
-            let current_ble_state = to_ble_game_state(&current_status, s.position().turn());
+            let current_status = session.game_state();
+            let current_ble_state = to_ble_game_state(&current_status, session.position().turn());
             let state_changed = prev_game_state.as_ref() != Some(&current_ble_state);
             if state_changed {
                 notifier.notify_game_state(&current_ble_state);
                 prev_game_state = Some(current_ble_state);
             }
 
-            if s.is_game_over() {
-                let final_status = s.game_state();
+            if session.is_game_over() {
+                let final_status = session.game_state();
                 log::info!("Game over: {:?}", final_status);
 
-                session = None;
+                board_state = BoardState::Idle;
                 white_config = None;
                 black_config = None;
                 prev_positions = None;
@@ -250,45 +307,6 @@ fn to_ble_game_state(
     GameState {
         status: ble_status,
         turn,
-    }
-}
-
-#[cfg(target_os = "espidf")]
-fn wait_for_starting_position<S, D>(
-    sensor: &mut S,
-    display: &mut D,
-) -> Result<shakmaty::ByColor<shakmaty::Bitboard>, S::Error>
-where
-    S: unnamed_chess_project::PieceSensor,
-    D: unnamed_chess_project::BoardDisplay,
-{
-    use esp_idf_svc::hal::delay::FreeRtos;
-    use unnamed_chess_project::feedback::BoardFeedback;
-    use unnamed_chess_project::setup::setup_feedback;
-
-    loop {
-        let positions = match sensor.read_positions() {
-            Ok(p) => p,
-            Err(e) => {
-                log::warn!("Sensor read failed: {e}");
-                FreeRtos::delay_ms(100);
-                continue;
-            }
-        };
-        match setup_feedback(&positions) {
-            Some(fb) => {
-                if let Err(e) = display.show(&fb) {
-                    log::warn!("LED update failed: {e}");
-                }
-                FreeRtos::delay_ms(50);
-            }
-            None => {
-                if let Err(e) = display.show(&BoardFeedback::default()) {
-                    log::warn!("LED clear failed: {e}");
-                }
-                return sensor.read_positions();
-            }
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         BleCommand, CommandResult, CommandSource, GameState, GameStatus, PlayerConfig, UNSET_BYTE,
     };
     use unnamed_chess_project::esp32::config::{LedPalette, SensorCalibration, SensorConfig};
-    use unnamed_chess_project::esp32::{start_ble, Esp32LedDisplay, Esp32PieceSensor};
+    use unnamed_chess_project::esp32::{Esp32LedDisplay, Esp32PieceSensor, start_ble};
     use unnamed_chess_project::feedback::BoardFeedback;
     use unnamed_chess_project::setup::setup_feedback;
     use unnamed_chess_project::{BoardDisplay, PieceSensor};


### PR DESCRIPTION
## Summary

Converts the blocking `wait_for_starting_position()` loop into a non-blocking state check within the main tick loop, enabling BLE commands (especially the new `CancelGame`) to be processed during piece setup. The main loop now uses an explicit `BoardState` state machine: Idle → AwaitingPieces → InProgress.

## Decisions & callouts

- `CancelGame` during `AwaitingPieces` is treated as a valid cancel (not "no game in progress") — the setup phase is an active game lifecycle state
- `Resign` during `AwaitingPieces` returns "no game in progress" — use `CancelGame` instead to abort setup
- The `AwaitingPieces` tick reads sensors non-blockingly each iteration, showing setup feedback LEDs until the starting position is detected