### PR TITLE
feat(companion): add Lichess bridge for AI games

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Project-specific instructions for AI coding agents working in this repository.
 
 ## Project Overview
 
-ESP32-S3 smart chess board firmware in Rust, plus an iOS companion app (SwiftUI + CoreBluetooth). Hall-effect sensors detect per-color piece positions; LEDs provide move feedback. Uses `shakmaty` for chess logic. The companion app connects via BLE to configure players and start games. Supports human-vs-human and human-vs-remote (companion-managed) modes.
+ESP32-S3 smart chess board firmware in Rust, plus an iOS companion app (SwiftUI + CoreBluetooth). Hall-effect sensors detect per-color piece positions; LEDs provide move feedback. Uses `shakmaty` for chess logic. The companion app connects via BLE to configure players and start games. Supports human-vs-human and human-vs-remote (companion-managed) modes. The companion app includes a Lichess bridge (`LichessService`) that challenges the Lichess AI and forwards moves bidirectionally between the board and Lichess.
 
 ## Build and Test Commands
 
@@ -124,7 +124,7 @@ Used by `ScriptedSensor` in `testutil/script.rs` and extensively in `player/huma
 
 ## Provisioning
 
-On boot the board enters BLE advertising mode with the name "ChessBoard". The iOS companion app connects via BLE, configures players, and starts games. Only sensor calibration data is persisted to NVS (in the separate `cal` partition). The companion app persists last-used player config to UserDefaults.
+On boot the board enters BLE advertising mode with the name "ChessBoard". The iOS companion app connects via BLE, configures players, and starts games. Only sensor calibration data is persisted to NVS (in the separate `cal` partition). The companion app persists last-used player config to UserDefaults and Lichess API tokens to Keychain.
 
 `just erase-nvs` clears the main NVS partition. It does not affect sensor calibration.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Without calibration, the firmware falls back to conservative defaults that may n
 
 ### Remote Player Architecture
 
-The board uses `RemotePlayer` to receive moves from an external source (e.g., the companion app or your own controller). The companion app handles configuring players, starting games, and can act as a bridge for remote opponents. Lichess integration is planned but not yet implemented.
+The board uses `RemotePlayer` to receive moves from an external source (e.g., the companion app or your own controller). The companion app handles configuring players, starting games, and acts as a bridge for remote opponents. It includes a Lichess integration that challenges the Lichess AI, streams game events via NDJSON, and forwards moves bidirectionally between the physical board and Lichess.
 
 ## Development
 

--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -1,4 +1,5 @@
 import CoreBluetooth
+import Foundation
 import Observation
 
 enum ConnectionState: Equatable {
@@ -36,7 +37,9 @@ extension ConnectionState {
 @Observable
 class BoardConnection {
     var connectionState: ConnectionState = .poweredOff
-    var gameStatus: GameStatus = .idle
+    var gameStatus: GameStatus = .idle {
+        didSet { handleGameStatusChange(gameStatus) }
+    }
     var lastCommandResult: CommandResult?
 
     /// Player types for each side, read from firmware on connect.
@@ -52,6 +55,16 @@ class BoardConnection {
 
     /// Called when the board emits a MovePlayed notification.
     var onMovePlayed: ((Turn, String) -> Void)?
+
+    /// Active Lichess bridge, if any. Owned here so it outlives NewGameView.
+    var lichessService: LichessService?
+
+    /// Lichess error message, preserved after the service is torn down.
+    /// This allows the UI to display the error even after the service is nilled.
+    var lichessError: String?
+
+    /// AI level to pass to LichessService.start() once the game reaches inProgress.
+    var pendingLichessLevel: Int?
 
     private var transport: BoardTransport?
 
@@ -159,6 +172,28 @@ class BoardConnection {
     func handleMovePlayed(color: Turn, uci: String) {
         lastMove = (color, uci)
         onMovePlayed?(color, uci)
+    }
+
+    // MARK: - Lichess lifecycle
+
+    /// Reacts to game status changes to manage the Lichess service lifecycle.
+    private func handleGameStatusChange(_ status: GameStatus) {
+        if status == .inProgress, let service = lichessService,
+            let level = pendingLichessLevel
+        {
+            pendingLichessLevel = nil
+            Task { await service.start(level: level) }
+        }
+
+        if status.isTerminal || status == .idle {
+            lichessService?.stop()
+            // Copy error before nilling so the UI can display it
+            if let service = lichessService, let error = service.error {
+                lichessError = error
+            }
+            lichessService = nil
+            onMovePlayed = nil
+        }
     }
 
     func restartScanning() {

--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -50,6 +50,9 @@ class BoardConnection {
     /// Last move played: (color: Turn, uci: String).
     var lastMove: (color: Turn, uci: String)?
 
+    /// Called when the board emits a MovePlayed notification.
+    var onMovePlayed: ((Turn, String) -> Void)?
+
     private var transport: BoardTransport?
 
     /// Production initializer. Callers must provide the transport explicitly.
@@ -155,6 +158,7 @@ class BoardConnection {
     /// Handles a move played notification from the board.
     func handleMovePlayed(color: Turn, uci: String) {
         lastMove = (color, uci)
+        onMovePlayed?(color, uci)
     }
 
     func restartScanning() {

--- a/companion/ChessBoard/Sources/Lichess/LichessAPI.swift
+++ b/companion/ChessBoard/Sources/Lichess/LichessAPI.swift
@@ -1,0 +1,250 @@
+import Foundation
+
+// MARK: - Event types
+
+enum LichessGameEvent {
+    case gameFull(id: String, initialMoves: String, aiLevel: Int)
+    case gameState(moves: String, status: String, winner: String?)
+}
+
+// MARK: - Errors
+
+enum LichessAPIError: Error {
+    case badStatus(Int)
+    case invalidResponse
+    case missingGameId
+}
+
+// MARK: - Protocol for testability
+
+protocol LichessAPIProtocol: Sendable {
+    func challengeAI(level: Int, color: String) async throws -> String
+    func streamGame(id: String) -> AsyncThrowingStream<LichessGameEvent, Error>
+    func makeMove(gameId: String, uci: String) async throws
+    func resignGame(gameId: String) async throws
+}
+
+// MARK: - LichessAPI
+
+/// Low-level Lichess API client.
+///
+/// All stored properties are immutable constants, so all methods are
+/// nonisolated and the type is Sendable.
+final class LichessAPI: LichessAPIProtocol, @unchecked Sendable {
+    private let token: String
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        token: String,
+        baseURL: URL = URL(string: "https://lichess.org/api")!,
+        session: URLSession = .shared
+    ) {
+        self.token = token
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    /// Challenge the Lichess AI. Returns the game ID.
+    func challengeAI(level: Int, color: String) async throws -> String {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("challenge/ai")
+        )
+        request.httpMethod = "POST"
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "Content-Type"
+        )
+        let body = "level=\(level)&color=\(color)"
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LichessAPIError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LichessAPIError.badStatus(http.statusCode)
+        }
+
+        guard
+            let json = try? JSONSerialization.jsonObject(
+                with: data
+            ) as? [String: Any],
+            let gameId = json["id"] as? String
+        else {
+            throw LichessAPIError.missingGameId
+        }
+        return gameId
+    }
+
+    /// Open an NDJSON stream for the given game.
+    /// Yields game events (GameFull, GameState) as they arrive.
+    func streamGame(id: String) -> AsyncThrowingStream<LichessGameEvent, Error>
+    {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent("board/game/stream/\(id)")
+        )
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let (bytes, response) = try await self.session.bytes(
+                        for: request
+                    )
+                    guard let http = response as? HTTPURLResponse else {
+                        continuation.finish(
+                            throwing: LichessAPIError.invalidResponse
+                        )
+                        return
+                    }
+                    guard (200..<300).contains(http.statusCode) else {
+                        continuation.finish(
+                            throwing: LichessAPIError.badStatus(
+                                http.statusCode
+                            )
+                        )
+                        return
+                    }
+
+                    var lineBuffer = ""
+                    for try await byte in bytes {
+                        let char = Character(UnicodeScalar(byte))
+                        if char == "\n" {
+                            let line = lineBuffer.trimmingCharacters(
+                                in: .whitespaces
+                            )
+                            lineBuffer = ""
+                            guard !line.isEmpty else { continue }
+                            if let event = Self.parseLine(line) {
+                                continuation.yield(event)
+                            }
+                        } else {
+                            lineBuffer.append(char)
+                        }
+                    }
+                    // Flush any remaining data
+                    let remaining = lineBuffer.trimmingCharacters(
+                        in: .whitespaces
+                    )
+                    if !remaining.isEmpty,
+                        let event = Self.parseLine(remaining)
+                    {
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Submit a move to an ongoing game.
+    func makeMove(gameId: String, uci: String) async throws {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent(
+                "board/game/\(gameId)/move/\(uci)"
+            )
+        )
+        request.httpMethod = "POST"
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LichessAPIError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LichessAPIError.badStatus(http.statusCode)
+        }
+    }
+
+    /// Resign an ongoing game.
+    func resignGame(gameId: String) async throws {
+        var request = URLRequest(
+            url: baseURL.appendingPathComponent(
+                "board/game/\(gameId)/resign"
+            )
+        )
+        request.httpMethod = "POST"
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LichessAPIError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LichessAPIError.badStatus(http.statusCode)
+        }
+    }
+
+    // MARK: - NDJSON parsing
+
+    private static func parseLine(_ line: String) -> LichessGameEvent? {
+        LichessEventParser.parse(line: line)
+    }
+}
+
+// MARK: - LichessEventParser
+
+/// Internal NDJSON event parser. Extracted for testability.
+enum LichessEventParser {
+    static func parse(line: String) -> LichessGameEvent? {
+        guard
+            let data = line.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data)
+                as? [String: Any],
+            let type = json["type"] as? String
+        else { return nil }
+
+        switch type {
+        case "gameFull":
+            guard let id = json["id"] as? String else { return nil }
+            let initialMoves: String
+            if let state = json["state"] as? [String: Any],
+                let moves = state["moves"] as? String
+            {
+                initialMoves = moves
+            } else {
+                initialMoves = ""
+            }
+            let aiLevel: Int
+            if let opponent = json["opponent"] as? [String: Any],
+                let level = opponent["aiLevel"] as? Int
+            {
+                aiLevel = level
+            } else {
+                aiLevel = 1
+            }
+            return .gameFull(
+                id: id,
+                initialMoves: initialMoves,
+                aiLevel: aiLevel
+            )
+
+        case "gameState":
+            guard let moves = json["moves"] as? String,
+                let status = json["status"] as? String
+            else { return nil }
+            let winner = json["winner"] as? String
+            return .gameState(moves: moves, status: status, winner: winner)
+
+        default:
+            return nil
+        }
+    }
+}

--- a/companion/ChessBoard/Sources/Lichess/LichessAPI.swift
+++ b/companion/ChessBoard/Sources/Lichess/LichessAPI.swift
@@ -9,15 +9,29 @@ enum LichessGameEvent {
 
 // MARK: - Errors
 
-enum LichessAPIError: Error {
+enum LichessAPIError: LocalizedError {
     case badStatus(Int)
     case invalidResponse
     case missingGameId
+
+    var errorDescription: String? {
+        switch self {
+        case .badStatus(401):
+            return "Invalid Lichess API token"
+        case .badStatus(let code):
+            return "Lichess API error (status \(code))"
+        case .invalidResponse:
+            return "Invalid response from Lichess"
+        case .missingGameId:
+            return "Lichess did not return a game ID"
+        }
+    }
 }
 
 // MARK: - Protocol for testability
 
 protocol LichessAPIProtocol: Sendable {
+    func validateToken() async throws
     func challengeAI(level: Int, color: String) async throws -> String
     func streamGame(id: String) -> AsyncThrowingStream<LichessGameEvent, Error>
     func makeMove(gameId: String, uci: String) async throws
@@ -43,6 +57,23 @@ final class LichessAPI: LichessAPIProtocol, @unchecked Sendable {
         self.token = token
         self.baseURL = baseURL
         self.session = session
+    }
+
+    /// Validate the stored token by calling GET /api/account.
+    /// Throws `LichessAPIError.badStatus(401)` for an invalid token.
+    func validateToken() async throws {
+        var request = URLRequest(url: baseURL.appendingPathComponent("account"))
+        request.setValue(
+            "Bearer \(token)",
+            forHTTPHeaderField: "Authorization"
+        )
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LichessAPIError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LichessAPIError.badStatus(http.statusCode)
+        }
     }
 
     /// Challenge the Lichess AI. Returns the game ID.
@@ -114,30 +145,14 @@ final class LichessAPI: LichessAPIProtocol, @unchecked Sendable {
                         return
                     }
 
-                    var lineBuffer = ""
-                    for try await byte in bytes {
-                        let char = Character(UnicodeScalar(byte))
-                        if char == "\n" {
-                            let line = lineBuffer.trimmingCharacters(
-                                in: .whitespaces
-                            )
-                            lineBuffer = ""
-                            guard !line.isEmpty else { continue }
-                            if let event = Self.parseLine(line) {
-                                continuation.yield(event)
-                            }
-                        } else {
-                            lineBuffer.append(char)
+                    for try await line in bytes.lines {
+                        let trimmed = line.trimmingCharacters(
+                            in: .whitespacesAndNewlines
+                        )
+                        guard !trimmed.isEmpty else { continue }
+                        if let event = Self.parseLine(trimmed) {
+                            continuation.yield(event)
                         }
-                    }
-                    // Flush any remaining data
-                    let remaining = lineBuffer.trimmingCharacters(
-                        in: .whitespaces
-                    )
-                    if !remaining.isEmpty,
-                        let event = Self.parseLine(remaining)
-                    {
-                        continuation.yield(event)
                     }
                     continuation.finish()
                 } catch {

--- a/companion/ChessBoard/Sources/Lichess/LichessService.swift
+++ b/companion/ChessBoard/Sources/Lichess/LichessService.swift
@@ -5,8 +5,21 @@ import Observation
 
 private let terminalStatuses: Set<String> = [
     "mate", "resign", "stalemate", "timeout", "draw", "outoftime", "cheat",
-    "noStart", "unknownFinish", "variantEnd",
+    "noStart", "unknownFinish", "variantEnd", "aborted",
 ]
+
+// MARK: - User-facing messages for terminal statuses
+
+private func terminalMessage(for status: String) -> String? {
+    switch status {
+    case "mate": return nil  // Board detects checkmate from position
+    case "resign": return "Opponent resigned"
+    case "timeout", "outoftime": return "Game ended: timeout"
+    case "aborted", "noStart": return "Game aborted"
+    case "draw", "stalemate": return "Game ended in a draw"
+    default: return "Game over"
+    }
+}
 
 // MARK: - LichessService
 
@@ -73,6 +86,7 @@ class LichessService {
         } catch {
             self.error = error.localizedDescription
             isActive = false
+            board.cancelGame()
         }
     }
 
@@ -85,8 +99,21 @@ class LichessService {
         // those echoes.
         guard color == humanColor else { return }
         guard let id = gameId, isActive else { return }
-        Task {
-            try? await api.makeMove(gameId: id, uci: uci)
+        Task { @MainActor in
+            // Re-check that the service is still active and the game ID hasn't changed
+            guard isActive, let currentGameId = gameId, currentGameId == id
+            else { return }
+            do {
+                try await api.makeMove(gameId: id, uci: uci)
+            } catch {
+                // Retry once before surfacing the error
+                do {
+                    try await api.makeMove(gameId: id, uci: uci)
+                } catch {
+                    self.error =
+                        "Move submission failed: \(error.localizedDescription)"
+                }
+            }
         }
     }
 
@@ -106,13 +133,15 @@ class LichessService {
         streamTask?.cancel()
         streamTask = Task { [weak self] in
             guard let self else { return }
-            let stream = api.streamGame(id: gameId)
             do {
-                for try await event in stream {
-                    self.handleEvent(event)
-                }
+                try await self.runStream(gameId: gameId)
             } catch {
-                if !Task.isCancelled {
+                // First attempt failed — try once more if not cancelled
+                guard !Task.isCancelled else { return }
+                do {
+                    try await self.runStream(gameId: gameId)
+                } catch {
+                    guard !Task.isCancelled else { return }
                     self.error = error.localizedDescription
                     self.isActive = false
                 }
@@ -120,19 +149,43 @@ class LichessService {
         }
     }
 
+    /// Runs the game stream until completion or error.
+    private func runStream(gameId: String) async throws {
+        let stream = api.streamGame(id: gameId)
+        for try await event in stream {
+            handleEvent(event)
+        }
+        // Normal stream completion (server closed the connection without a
+        // terminal event) — mark service as inactive.
+        if isActive {
+            isActive = false
+        }
+    }
+
     private func handleEvent(_ event: LichessGameEvent) {
         switch event {
         case .gameFull(_, let initialMoves, _):
             let plies = movesCount(initialMoves)
-            lastMoveCount = plies
-            // If the AI moved first (human is black), submit that initial move
-            if plies > 0 {
-                submitLatestAIMove(from: initialMoves, previousCount: 0)
+            // If the AI moved first (human is black), submit that initial move.
+            // On stream reconnect, only submit if there are genuinely new moves
+            // beyond what we've already processed (use lastMoveCount as baseline).
+            if plies > lastMoveCount {
+                submitLatestAIMove(
+                    from: initialMoves,
+                    previousCount: lastMoveCount
+                )
             }
+            lastMoveCount = plies
 
         case .gameState(let moves, let status, _):
             if terminalStatuses.contains(status) {
-                board.cancelGame()
+                // For mate, the board detects checkmate from position itself.
+                // For all other terminal states, force the board out of the
+                // current game and surface a human-readable message.
+                if status != "mate" {
+                    board.cancelGame()
+                    error = terminalMessage(for: status)
+                }
                 streamTask?.cancel()
                 streamTask = nil
                 isActive = false

--- a/companion/ChessBoard/Sources/Lichess/LichessService.swift
+++ b/companion/ChessBoard/Sources/Lichess/LichessService.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Observation
+
+// MARK: - Terminal status set
+
+private let terminalStatuses: Set<String> = [
+    "mate", "resign", "stalemate", "timeout", "draw", "outoftime", "cheat",
+    "noStart", "unknownFinish", "variantEnd",
+]
+
+// MARK: - LichessService
+
+/// Orchestrates a Lichess game, bridging between the board and Lichess API.
+///
+/// Lifecycle:
+/// 1. `start()` → challenges AI, opens stream
+/// 2. Receives board's `MovePlayed` → filters by humanColor → sends to Lichess
+///    via `makeMove`
+/// 3. Receives Lichess AI move → sends to board via `board.submitMove()`
+/// 4. Lichess game-over event → calls `board.cancelGame()` to sync board state
+/// 5. Board game ends → `stop()`
+@MainActor
+@Observable
+class LichessService {
+    private let api: any LichessAPIProtocol
+    private let board: BoardConnection
+    /// Which color is the human on the physical board.
+    private let humanColor: Turn
+
+    var gameId: String?
+    var isActive: Bool = false
+    var error: String?
+
+    private var streamTask: Task<Void, Never>?
+
+    /// Number of half-moves (plies) seen in the last stream event.
+    /// Used to detect new AI moves without re-processing already-seen ones.
+    private var lastMoveCount: Int = 0
+
+    init(
+        token: String,
+        board: BoardConnection,
+        humanColor: Turn
+    ) {
+        self.api = LichessAPI(token: token)
+        self.board = board
+        self.humanColor = humanColor
+    }
+
+    /// Designated initializer for testing — accepts any LichessAPIProtocol.
+    init(
+        api: any LichessAPIProtocol,
+        board: BoardConnection,
+        humanColor: Turn
+    ) {
+        self.api = api
+        self.board = board
+        self.humanColor = humanColor
+    }
+
+    func start(level: Int) async {
+        guard !isActive else { return }
+        error = nil
+        isActive = true
+        lastMoveCount = 0
+
+        let colorParam = humanColor == .white ? "white" : "black"
+
+        do {
+            let id = try await api.challengeAI(level: level, color: colorParam)
+            gameId = id
+            startStream(gameId: id)
+        } catch {
+            self.error = error.localizedDescription
+            isActive = false
+        }
+    }
+
+    /// Called when the board emits a MovePlayed event.
+    /// Only forwards to Lichess if the move is from the human player.
+    func boardMovePlayed(color: Turn, uci: String) {
+        // Echo suppression: only forward moves from the human side.
+        // When LichessService submits an AI move via board.submitMove(),
+        // the board echoes it back as a MovePlayed event. We must ignore
+        // those echoes.
+        guard color == humanColor else { return }
+        guard let id = gameId, isActive else { return }
+        Task {
+            try? await api.makeMove(gameId: id, uci: uci)
+        }
+    }
+
+    func stop() {
+        streamTask?.cancel()
+        streamTask = nil
+        isActive = false
+        if let id = gameId {
+            gameId = nil
+            Task { try? await api.resignGame(gameId: id) }
+        }
+    }
+
+    // MARK: - Private
+
+    private func startStream(gameId: String) {
+        streamTask?.cancel()
+        streamTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = api.streamGame(id: gameId)
+            do {
+                for try await event in stream {
+                    self.handleEvent(event)
+                }
+            } catch {
+                if !Task.isCancelled {
+                    self.error = error.localizedDescription
+                    self.isActive = false
+                }
+            }
+        }
+    }
+
+    private func handleEvent(_ event: LichessGameEvent) {
+        switch event {
+        case .gameFull(_, let initialMoves, _):
+            let plies = movesCount(initialMoves)
+            lastMoveCount = plies
+            // If the AI moved first (human is black), submit that initial move
+            if plies > 0 {
+                submitLatestAIMove(from: initialMoves, previousCount: 0)
+            }
+
+        case .gameState(let moves, let status, _):
+            if terminalStatuses.contains(status) {
+                board.cancelGame()
+                streamTask?.cancel()
+                streamTask = nil
+                isActive = false
+                return
+            }
+            let plies = movesCount(moves)
+            if plies > lastMoveCount {
+                submitLatestAIMove(
+                    from: moves,
+                    previousCount: lastMoveCount
+                )
+                lastMoveCount = plies
+            }
+        }
+    }
+
+    /// Extracts and submits the latest AI move from the Lichess move list.
+    ///
+    /// The AI plays the opposite color from humanColor. In a space-separated
+    /// UCI move list, white plays on even indices (0, 2, 4...) and black on
+    /// odd indices (1, 3, 5...). We find the last move that belongs to the AI.
+    private func submitLatestAIMove(
+        from moves: String,
+        previousCount: Int
+    ) {
+        let allMoves = moves.split(separator: " ").map(String.init)
+        guard !allMoves.isEmpty else { return }
+
+        // The AI color is opposite of the human.
+        // White moves are at even indices (0-based), black at odd.
+        let aiIsBlack = humanColor == .white
+
+        // Look for the most recent AI move among the new moves
+        for idx in stride(
+            from: allMoves.count - 1,
+            through: previousCount,
+            by: -1
+        ) {
+            let moveIsBlack = (idx % 2) == 1
+            if moveIsBlack == aiIsBlack {
+                board.submitMove(allMoves[idx])
+                return
+            }
+        }
+    }
+
+    /// Count the number of half-moves (plies) in a space-separated UCI string.
+    private func movesCount(_ moves: String) -> Int {
+        moves.isEmpty ? 0 : moves.split(separator: " ").count
+    }
+}

--- a/companion/ChessBoard/Sources/Persistence/KeychainStore.swift
+++ b/companion/ChessBoard/Sources/Persistence/KeychainStore.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Minimal Keychain wrapper for storing sensitive data (API tokens).
+enum KeychainStore {
+    static let service = "com.chessboard.lichess"
+
+    /// Save a value to Keychain under the given key.
+    static func save(_ value: String, forKey key: String) throws {
+        let data = value.data(using: .utf8) ?? Data()
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+
+        // Try to delete existing value first (ignore errors)
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+        ]
+
+        // Now add the new value
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status)
+        }
+    }
+
+    /// Retrieve a value from Keychain.
+    static func retrieve(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Delete a value from Keychain.
+    static func delete(forKey key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+}
+
+enum KeychainError: LocalizedError {
+    case saveFailed(OSStatus)
+    case deleteFailed(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .saveFailed(let status):
+            return "Failed to save to Keychain (status: \(status))"
+        case .deleteFailed(let status):
+            return "Failed to delete from Keychain (status: \(status))"
+        }
+    }
+}

--- a/companion/ChessBoard/Sources/Views/ActiveGameView.swift
+++ b/companion/ChessBoard/Sources/Views/ActiveGameView.swift
@@ -21,6 +21,15 @@ struct ActiveGameView: View {
                     .foregroundStyle(.secondary)
             }
 
+            if let lichessError = board.lichessError
+                ?? board.lichessService?.error
+            {
+                Label(lichessError, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                    .font(.callout)
+                    .multilineTextAlignment(.center)
+            }
+
             Spacer()
 
             if board.gameStatus == .awaitingPieces {

--- a/companion/ChessBoard/Sources/Views/NewGameView.swift
+++ b/companion/ChessBoard/Sources/Views/NewGameView.swift
@@ -1,3 +1,4 @@
+import Security
 import SwiftUI
 
 struct NewGameView: View {
@@ -11,10 +12,18 @@ struct NewGameView: View {
     @State private var hasLoaded = false
     @State private var isStarting = false
 
+    // Lichess configuration
+    @State private var lichessToken: String = ""
+    @State private var lichessLevel: Int = 3
+
     var body: some View {
         Form {
             playerSection("White", type: $whiteType)
             playerSection("Black", type: $blackType)
+
+            if isLichessGame {
+                lichessConfigSection
+            }
 
             if let error {
                 Section {
@@ -23,15 +32,12 @@ struct NewGameView: View {
                         systemImage: "exclamationmark.triangle"
                     )
                     .foregroundStyle(.red)
-                    Button("Retry") {
-                        startGame()
-                    }
                 }
             }
 
             Section {
                 Button {
-                    startGame()
+                    Task { await startGame() }
                 } label: {
                     HStack {
                         Text("Start Game")
@@ -76,6 +82,24 @@ struct NewGameView: View {
         }
     }
 
+    // MARK: - Derived helpers
+
+    /// True when at least one side is Remote (Lichess AI).
+    private var isLichessGame: Bool {
+        whiteType == .remote || blackType == .remote
+    }
+
+    /// The color that is NOT remote (nil when both are remote or neither).
+    private var humanColor: Turn? {
+        switch (whiteType, blackType) {
+        case (.human, .remote): return .white
+        case (.remote, .human): return .black
+        default: return nil
+        }
+    }
+
+    // MARK: - Sub-views
+
     private func playerSection(
         _ title: String,
         type: Binding<PlayerType>
@@ -83,19 +107,77 @@ struct NewGameView: View {
         Section(title) {
             Picker("Player", selection: type) {
                 Text("Human").tag(PlayerType.human)
-                Text("Remote").tag(PlayerType.remote)
+                Text("Lichess AI").tag(PlayerType.remote)
             }
             .pickerStyle(.segmented)
         }
     }
 
-    private func startGame() {
+    @ViewBuilder
+    private var lichessConfigSection: some View {
+        Section("Lichess AI") {
+            SecureField("API Token", text: $lichessToken)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            Picker("AI Level", selection: $lichessLevel) {
+                ForEach(1...8, id: \.self) { level in
+                    Text("Level \(level)").tag(level)
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func startGame() async {
         error = nil
+        board.lichessError = nil  // Clear any previous Lichess errors
         savePreferences()
         guard board.connectionState == .ready else {
             error = "Board disconnected"
             return
         }
+
+        // Set up Lichess bridge when one side is remote
+        if isLichessGame, let color = humanColor {
+            let trimmedToken = lichessToken.trimmingCharacters(in: .whitespaces)
+            guard !trimmedToken.isEmpty else {
+                error = "Lichess API token is required"
+                return
+            }
+
+            // Validate token before starting the board game
+            isStarting = true
+            let api = LichessAPI(token: trimmedToken)
+            do {
+                try await api.validateToken()
+            } catch {
+                isStarting = false
+                self.error = error.localizedDescription
+                return
+            }
+
+            let service = LichessService(
+                token: trimmedToken,
+                board: board,
+                humanColor: color
+            )
+            board.lichessService = service
+            board.pendingLichessLevel = lichessLevel
+            board.onMovePlayed = { [weak service] turn, uci in
+                service?.boardMovePlayed(color: turn, uci: uci)
+            }
+        } else if isLichessGame {
+            // Both sides are remote — not a supported configuration
+            error = "At least one side must be human for a Lichess game"
+            return
+        } else {
+            board.lichessService = nil
+            board.pendingLichessLevel = nil
+            board.onMovePlayed = nil
+        }
+
         isStarting = true
         board.configureAndStart(white: whiteType, black: blackType)
     }
@@ -114,12 +196,43 @@ struct NewGameView: View {
         {
             blackType = type
         }
+        // Load Lichess token from Keychain
+        if let token = KeychainStore.retrieve(forKey: "lichess_token") {
+            lichessToken = token
+        }
+        // Load Lichess level from UserDefaults
+        if let savedLevel = defaults.object(forKey: "lichess_level") as? Int {
+            lichessLevel = savedLevel
+        }
     }
 
     private func savePreferences() {
         let defaults = UserDefaults.standard
         defaults.set(Int(whiteType.rawValue), forKey: "chess_white_player")
         defaults.set(Int(blackType.rawValue), forKey: "chess_black_player")
+        // Save Lichess level to UserDefaults
+        defaults.set(lichessLevel, forKey: "lichess_level")
+        // Save Lichess token to Keychain
+        let trimmedToken = lichessToken.trimmingCharacters(in: .whitespaces)
+        if !trimmedToken.isEmpty {
+            do {
+                try KeychainStore.save(trimmedToken, forKey: "lichess_token")
+            } catch {
+                // Silently fail on Keychain save errors (non-critical)
+                print(
+                    "Warning: Failed to save Lichess token to Keychain: \(error)"
+                )
+            }
+        } else {
+            do {
+                try KeychainStore.delete(forKey: "lichess_token")
+            } catch {
+                // Silently fail on Keychain delete errors (non-critical)
+                print(
+                    "Warning: Failed to delete Lichess token from Keychain: \(error)"
+                )
+            }
+        }
     }
 
     #if DEBUG
@@ -127,8 +240,18 @@ struct NewGameView: View {
             let defaults = UserDefaults.standard
             defaults.removeObject(forKey: "chess_white_player")
             defaults.removeObject(forKey: "chess_black_player")
+            defaults.removeObject(forKey: "lichess_level")
+            do {
+                try KeychainStore.delete(forKey: "lichess_token")
+            } catch {
+                print(
+                    "Warning: Failed to delete Lichess token from Keychain: \(error)"
+                )
+            }
             whiteType = .human
             blackType = .remote
+            lichessToken = ""
+            lichessLevel = 3
             error = nil
         }
     #endif
@@ -138,5 +261,15 @@ struct NewGameView: View {
     #Preview("Idle") {
         NavigationStack { NewGameView() }
             .environment(BoardConnection(connectionState: .ready))
+    }
+    #Preview("Lichess Remote") {
+        NavigationStack { NewGameView() }
+            .environment(
+                BoardConnection(
+                    connectionState: .ready,
+                    whitePlayerType: .human,
+                    blackPlayerType: .remote
+                )
+            )
     }
 #endif

--- a/companion/ChessBoard/Tests/LichessAPITests.swift
+++ b/companion/ChessBoard/Tests/LichessAPITests.swift
@@ -1,0 +1,147 @@
+import XCTest
+
+@testable import ChessBoard
+
+// MARK: - LichessAPITests
+
+final class LichessAPITests: XCTestCase {
+    // MARK: - parseLine tests (via streamGame parsing logic)
+    // We test parsing indirectly by feeding sample Lichess NDJSON responses
+    // through a mock URLSession.
+
+    func testParseGameFullEvent() throws {
+        let line = """
+            {"type":"gameFull","id":"abc123","opponent":{"aiLevel":3},"state":{"moves":"e2e4 e7e5","status":"started"}}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameFull(let id, let initialMoves, let aiLevel) = event
+        else {
+            XCTFail("Expected gameFull, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(id, "abc123")
+        XCTAssertEqual(initialMoves, "e2e4 e7e5")
+        XCTAssertEqual(aiLevel, 3)
+    }
+
+    func testParseGameFullEventNoMoves() throws {
+        let line = """
+            {"type":"gameFull","id":"xyz","opponent":{"aiLevel":1},"state":{"moves":"","status":"started"}}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameFull(let id, let initialMoves, let aiLevel) = event
+        else {
+            XCTFail("Expected gameFull, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(id, "xyz")
+        XCTAssertEqual(initialMoves, "")
+        XCTAssertEqual(aiLevel, 1)
+    }
+
+    func testParseGameFullEventMissingId() {
+        let line = """
+            {"type":"gameFull","opponent":{"aiLevel":1},"state":{"moves":""}}
+            """
+        let event = parseLineForTest(line)
+        XCTAssertNil(event, "Should return nil when id is missing")
+    }
+
+    func testParseGameFullEventMissingOpponent() {
+        // When opponent key is absent, aiLevel defaults to 1
+        let line = """
+            {"type":"gameFull","id":"abc","state":{"moves":""}}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameFull(let id, _, let aiLevel) = event else {
+            XCTFail("Expected gameFull, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(id, "abc")
+        XCTAssertEqual(aiLevel, 1)
+    }
+
+    func testParseGameStateEvent() {
+        let line = """
+            {"type":"gameState","moves":"e2e4 e7e5 g1f3","status":"started","winner":null}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameState(let moves, let status, let winner) = event else {
+            XCTFail("Expected gameState, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(moves, "e2e4 e7e5 g1f3")
+        XCTAssertEqual(status, "started")
+        XCTAssertNil(winner)
+    }
+
+    func testParseGameStateEventWithWinner() {
+        let line = """
+            {"type":"gameState","moves":"e2e4 e7e5","status":"mate","winner":"white"}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameState(let moves, let status, let winner) = event else {
+            XCTFail("Expected gameState, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(moves, "e2e4 e7e5")
+        XCTAssertEqual(status, "mate")
+        XCTAssertEqual(winner, "white")
+    }
+
+    func testParseGameStateMissingMoves() {
+        let line = """
+            {"type":"gameState","status":"started"}
+            """
+        let event = parseLineForTest(line)
+        XCTAssertNil(event, "Should return nil when moves field is missing")
+    }
+
+    func testParseGameStateMissingStatus() {
+        let line = """
+            {"type":"gameState","moves":"e2e4"}
+            """
+        let event = parseLineForTest(line)
+        XCTAssertNil(event, "Should return nil when status field is missing")
+    }
+
+    func testParseUnknownType() {
+        let line = """
+            {"type":"ping"}
+            """
+        let event = parseLineForTest(line)
+        XCTAssertNil(event, "Should return nil for unknown event types")
+    }
+
+    func testParseEmptyString() {
+        XCTAssertNil(parseLineForTest(""))
+    }
+
+    func testParseInvalidJSON() {
+        XCTAssertNil(parseLineForTest("not json"))
+    }
+
+    func testParseGameFullMissingStateKey() {
+        // State key absent → initialMoves defaults to ""
+        let line = """
+            {"type":"gameFull","id":"abc","opponent":{"aiLevel":2}}
+            """
+        let event = parseLineForTest(line)
+        guard case .gameFull(_, let initialMoves, _) = event else {
+            XCTFail("Expected gameFull")
+            return
+        }
+        XCTAssertEqual(initialMoves, "")
+    }
+
+    // MARK: - Helpers
+
+    /// Reaches into LichessAPI's parseLine via a mock stream.
+    /// Since parseLine is private, we exercise it through a MockURLSession
+    /// that serves a single-line NDJSON response.
+    private func parseLineForTest(_ line: String) -> LichessGameEvent? {
+        // We can't call parseLine directly (it's private/static).
+        // Instead we use the testable LichessEventParser helper.
+        LichessEventParser.parse(line: line)
+    }
+}

--- a/companion/ChessBoard/Tests/LichessServiceTests.swift
+++ b/companion/ChessBoard/Tests/LichessServiceTests.swift
@@ -15,6 +15,11 @@ final class MockLichessAPI: LichessAPIProtocol, @unchecked Sendable {
     /// Controls events emitted by streamGame. Set before calling start().
     var streamEvents: [LichessGameEvent] = []
 
+    var validateTokenError: Error?
+    func validateToken() async throws {
+        if let error = validateTokenError { throw error }
+    }
+
     func challengeAI(level: Int, color: String) async throws -> String {
         switch challengeAIResult {
         case .success(let id): return id

--- a/companion/ChessBoard/Tests/LichessServiceTests.swift
+++ b/companion/ChessBoard/Tests/LichessServiceTests.swift
@@ -1,0 +1,315 @@
+import XCTest
+
+@testable import ChessBoard
+
+// MARK: - Mock API
+
+/// A mock LichessAPI for testing LichessService.
+final class MockLichessAPI: LichessAPIProtocol, @unchecked Sendable {
+    var challengeAIResult: Result<String, Error> = .success("test-game-id")
+    var makeMoveCallCount = 0
+    var makeMoveArgs: [(gameId: String, uci: String)] = []
+    var resignCallCount = 0
+    var resignArgs: [String] = []
+
+    /// Controls events emitted by streamGame. Set before calling start().
+    var streamEvents: [LichessGameEvent] = []
+
+    func challengeAI(level: Int, color: String) async throws -> String {
+        switch challengeAIResult {
+        case .success(let id): return id
+        case .failure(let error): throw error
+        }
+    }
+
+    func streamGame(id: String) -> AsyncThrowingStream<LichessGameEvent, Error>
+    {
+        let events = streamEvents
+        return AsyncThrowingStream { continuation in
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+
+    func makeMove(gameId: String, uci: String) async throws {
+        makeMoveCallCount += 1
+        makeMoveArgs.append((gameId, uci))
+    }
+
+    func resignGame(gameId: String) async throws {
+        resignCallCount += 1
+        resignArgs.append(gameId)
+    }
+}
+
+// MARK: - LichessServiceTests
+
+@MainActor
+final class LichessServiceTests: XCTestCase {
+    // MARK: - Echo suppression
+
+    func testBoardMovePlayedForwardsHumanMoves() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+        service.gameId = "game1"
+        service.isActive = true
+
+        service.boardMovePlayed(color: .white, uci: "e2e4")
+
+        // Allow the Task inside boardMovePlayed to execute.
+        // Task.yield() alone is not sufficient when the spawned Task calls an
+        // async method; a short sleep gives the Swift concurrency runtime time
+        // to schedule and complete the child Task.
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.makeMoveCallCount, 1)
+        XCTAssertEqual(api.makeMoveArgs.first?.uci, "e2e4")
+    }
+
+    func testBoardMovePlayedIgnoresAIMoves() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white  // human is white
+        )
+        service.gameId = "game1"
+        service.isActive = true
+
+        // Black move — this is the AI's echo, must be suppressed
+        service.boardMovePlayed(color: .black, uci: "e7e5")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(
+            api.makeMoveCallCount,
+            0,
+            "AI echo must not be forwarded to Lichess"
+        )
+    }
+
+    func testBoardMovePlayedIgnoresWhenNotActive() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+        service.gameId = "game1"
+        service.isActive = false  // service not active
+
+        service.boardMovePlayed(color: .white, uci: "e2e4")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.makeMoveCallCount, 0)
+    }
+
+    func testBoardMovePlayedIgnoresWhenNoGameId() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+        service.gameId = nil
+        service.isActive = true
+
+        service.boardMovePlayed(color: .white, uci: "e2e4")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.makeMoveCallCount, 0)
+    }
+
+    // MARK: - Terminal state handling
+
+    func testTerminalGameStateTriggersCancelGame() async {
+        let api = MockLichessAPI()
+        api.streamEvents = [
+            .gameState(moves: "e2e4 e7e5", status: "mate", winner: "white")
+        ]
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        await service.start(level: 1)
+
+        // Give the stream task time to run
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(
+            service.isActive,
+            "Service should be inactive after terminal gameState"
+        )
+        // board.cancelGame() should have been called — verify via lastCommandResult
+        // (cancelGame calls transport?.write but transport is nil in tests;
+        //  we verify the service's isActive is false as the primary signal)
+    }
+
+    func testResignGameStateTriggersCancelGame() async {
+        let api = MockLichessAPI()
+        api.streamEvents = [
+            .gameState(moves: "e2e4", status: "resign", winner: "white")
+        ]
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        await service.start(level: 3)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(service.isActive)
+    }
+
+    func testStalemateGameStateTriggersCancelGame() async {
+        let api = MockLichessAPI()
+        api.streamEvents = [
+            .gameState(moves: "e2e4 e7e5", status: "stalemate", winner: nil)
+        ]
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .black
+        )
+
+        await service.start(level: 5)
+
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(service.isActive)
+    }
+
+    // MARK: - start() lifecycle
+
+    func testStartSetsGameId() async {
+        let api = MockLichessAPI()
+        api.challengeAIResult = .success("new-game-42")
+        api.streamEvents = []
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        await service.start(level: 2)
+
+        XCTAssertEqual(service.gameId, "new-game-42")
+        XCTAssertTrue(service.isActive)
+    }
+
+    func testStartSetsErrorOnAPIFailure() async {
+        struct FakeError: Error, LocalizedError {
+            var errorDescription: String? { "Network error" }
+        }
+        let api = MockLichessAPI()
+        api.challengeAIResult = .failure(FakeError())
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        await service.start(level: 1)
+
+        XCTAssertFalse(service.isActive)
+        XCTAssertNotNil(service.error)
+    }
+
+    // MARK: - stop()
+
+    func testStopCancelsStreamAndResigns() async {
+        let api = MockLichessAPI()
+        api.streamEvents = []
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        await service.start(level: 1)
+        XCTAssertTrue(service.isActive)
+        let capturedGameId = service.gameId
+
+        service.stop()
+
+        XCTAssertFalse(service.isActive)
+        XCTAssertNil(service.gameId)
+
+        // Allow the resign Task to run
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.resignCallCount, 1)
+        XCTAssertEqual(api.resignArgs.first, capturedGameId)
+    }
+
+    func testStopWhenNotActiveDoesNotResign() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .white
+        )
+
+        service.stop()
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.resignCallCount, 0)
+    }
+
+    // MARK: - Echo suppression with human as black
+
+    func testEchoSuppressionHumanIsBlack() async {
+        let api = MockLichessAPI()
+        let board = BoardConnection(connectionState: .ready)
+        let service = LichessService(
+            api: api,
+            board: board,
+            humanColor: .black  // human plays black
+        )
+        service.gameId = "game2"
+        service.isActive = true
+
+        // White move — this is the AI's echo (AI plays white)
+        service.boardMovePlayed(color: .white, uci: "e2e4")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(
+            api.makeMoveCallCount,
+            0,
+            "White move must be suppressed when human is black"
+        )
+
+        // Black move — this is the human
+        service.boardMovePlayed(color: .black, uci: "e7e5")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertEqual(api.makeMoveCallCount, 1)
+        XCTAssertEqual(api.makeMoveArgs.first?.uci, "e7e5")
+    }
+}


### PR DESCRIPTION
## Summary

Adds Lichess game integration to the iOS companion app. The app now acts as both game controller and remote player bridge — it manages the Lichess HTTP stream, forwards Lichess AI moves to the board via `SubmitMove`, and forwards human moves (from `MovePlayed` events) to Lichess. No firmware changes required.

## References

- ADR: `docs/adrs/0001-separate-board-firmware-from-client-responsibilities.md`

## Decisions & callouts

- **Echo suppression**: The board emits `MovePlayed` for all moves (human and remote). `LichessService` tracks `humanColor` and only forwards moves matching the human side, preventing feedback loops.
- **Challenge timing**: The Lichess challenge is created after the board enters `InProgress` (not during `AwaitingPieces`), avoiding the Lichess clock running while pieces are being placed.
- **Lifecycle ownership**: `LichessService` is owned by `BoardConnection` (not the transient `NewGameView`) so it survives view transitions. A `didSet` on `gameStatus` manages the start/stop lifecycle.
- **Error persistence**: `BoardConnection.lichessError` preserves error messages after service teardown, since the service is nilled on `.idle`/terminal transitions.
- **`LichessAPI` is a `final class` with `@unchecked Sendable`** (not an actor) since all stored properties are immutable `let` constants. A `LichessAPIProtocol` enables mock-based testing.
- **NDJSON parsing** uses `bytes.lines` for UTF-8 safe line iteration.
- **BLE reconnection** during a Lichess game is a known limitation — if an AI move arrives during a BLE disconnect, it may be lost. The stream continues and forwarding resumes on reconnect, but move delivery is not guaranteed.
- **Token storage** uses Keychain via `SecureField` input. Users can clear stored tokens by emptying the field.

## Manual testing

- [x] Connect to board via BLE, configure one side as Remote, enter a Lichess API token and AI level, start game — verify Lichess challenge is created after pieces are placed and board enters InProgress
- [x] Play a move on the physical board — verify it appears on Lichess
- [x] Wait for Lichess AI to respond — verify the AI move is submitted to the board
- [x] End the game (checkmate or resign) — verify Lichess game is resigned/cleaned up
- [x] Enter an invalid token and start a game — verify error is displayed
- [x] Verify token is pre-filled on next app launch (Keychain persistence)