### PR TITLE
style(companion): dictionary shorthand and GameStatus display refactors

### DIFF
--- a/companion/ChessBoard/Sources/BLE/BLETransport.swift
+++ b/companion/ChessBoard/Sources/BLE/BLETransport.swift
@@ -7,7 +7,7 @@ final class BLETransport: NSObject, BoardTransport,
 
     private var centralManager: CBCentralManager!
     private var peripheral: CBPeripheral?
-    private var characteristics: [CBUUID: CBCharacteristic] = [:]
+    private var characteristics = [CBUUID: CBCharacteristic]()
     private var awaitingInitialState = false
 
     override init() {

--- a/companion/ChessBoard/Sources/Models/GameStatus+Display.swift
+++ b/companion/ChessBoard/Sources/Models/GameStatus+Display.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+extension GameStatus {
+    var displayText: String {
+        switch self {
+        case .idle: return "No Game"
+        case .awaitingPieces: return "Set Up Starting Position"
+        case .inProgress: return "In Progress"
+        case .checkmate(let loser):
+            return "Checkmate – \(loser == .white ? "White" : "Black") loses"
+        case .stalemate: return "Stalemate"
+        case .resigned(let color):
+            return "\(color == .white ? "White" : "Black") Resigned"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .idle: return "square.dashed"
+        case .awaitingPieces: return "checkerboard.rectangle"
+        case .inProgress: return "play.fill"
+        case .checkmate: return "crown.fill"
+        case .stalemate: return "equal.circle.fill"
+        case .resigned: return "flag.fill"
+        }
+    }
+
+    var displayColor: Color {
+        switch self {
+        case .idle: return .secondary
+        case .awaitingPieces: return .blue
+        case .inProgress: return .green
+        case .checkmate: return .orange
+        default: return .secondary
+        }
+    }
+}

--- a/companion/ChessBoard/Sources/Views/ActiveGameView.swift
+++ b/companion/ChessBoard/Sources/Views/ActiveGameView.swift
@@ -8,11 +8,11 @@ struct ActiveGameView: View {
         VStack(spacing: 32) {
             Spacer()
 
-            Image(systemName: statusIcon)
+            Image(systemName: board.gameStatus.iconName)
                 .font(.system(size: 48))
-                .foregroundStyle(statusColor)
+                .foregroundStyle(board.gameStatus.displayColor)
 
-            Text(statusText)
+            Text(board.gameStatus.displayText)
                 .font(.largeTitle.bold())
 
             if board.gameStatus == .inProgress {
@@ -75,39 +75,6 @@ struct ActiveGameView: View {
         return components[1] == "w" ? "White to move" : "Black to move"
     }
 
-    private var statusText: String {
-        switch board.gameStatus {
-        case .idle: return "No Game"
-        case .awaitingPieces: return "Set Up Starting Position"
-        case .inProgress: return "In Progress"
-        case .checkmate(let loser):
-            return "Checkmate – \(loser == .white ? "White" : "Black") loses"
-        case .stalemate: return "Stalemate"
-        case .resigned(let color):
-            return "\(color == .white ? "White" : "Black") Resigned"
-        }
-    }
-
-    private var statusIcon: String {
-        switch board.gameStatus {
-        case .idle: return "square.dashed"
-        case .awaitingPieces: return "checkerboard.rectangle"
-        case .inProgress: return "play.fill"
-        case .checkmate: return "crown.fill"
-        case .stalemate: return "equal.circle.fill"
-        case .resigned: return "flag.fill"
-        }
-    }
-
-    private var statusColor: Color {
-        switch board.gameStatus {
-        case .idle: return .secondary
-        case .awaitingPieces: return .blue
-        case .inProgress: return .green
-        case .checkmate: return .orange
-        default: return .secondary
-        }
-    }
 }
 
 #if DEBUG


### PR DESCRIPTION
## Summary

Applies two code quality improvements from PR #101 review feedback: dictionary literal shorthand in BLETransport, and extracting GameStatus display computed properties out of ActiveGameView into a reusable extension.

Both are pure refactors with no behavior change.

## Changes

- **BLETransport:** Use `[CBUUID: CBCharacteristic]()` initializer instead of `= [:]` for consistency with Swift shorthand style.
- **GameStatus+Display:** Move `statusText`, `statusIcon`, and `statusColor` from `ActiveGameView` into a SwiftUI extension on `GameStatus` (`displayText`, `iconName`, `displayColor`), making them reusable across views.