### PR TITLE
test(companion): add MockTransport for BLE testing

### DIFF
--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -75,9 +75,9 @@ class BoardConnection {
     }
 
     #if DEBUG
-        /// Creates a BoardConnection with pre-set state and no BLE transport.
-        /// Commands are no-ops (transport is nil). For use in #Preview macros.
-        init(
+        /// Creates a BoardConnection backed by a MockTransport with pre-set state.
+        /// For use in #Preview macros and tests.
+        convenience init(
             connectionState: ConnectionState = .ready,
             gameStatus: GameStatus = .idle,
             currentPosition: String? = nil,
@@ -85,7 +85,7 @@ class BoardConnection {
             whitePlayerType: PlayerType? = .human,
             blackPlayerType: PlayerType? = .remote
         ) {
-            self.transport = nil
+            self.init(transport: MockTransport())
             self.connectionState = connectionState
             self.gameStatus = gameStatus
             self.currentPosition = currentPosition

--- a/companion/ChessBoard/Sources/BLE/MockTransport.swift
+++ b/companion/ChessBoard/Sources/BLE/MockTransport.swift
@@ -1,0 +1,45 @@
+#if DEBUG
+    import CoreBluetooth
+    import Foundation
+
+    /// A mock BoardTransport that records all write and lifecycle calls.
+    /// Available in DEBUG builds for use in previews and tests.
+    @MainActor
+    final class MockTransport: BoardTransport {
+        weak var owner: BoardConnection?
+
+        // MARK: - write(_:to:)
+
+        var writeCallCount = 0
+        var writeArgs: [(data: Data, characteristic: CBUUID)] = []
+
+        func write(_ data: Data, to characteristic: CBUUID) {
+            writeCallCount += 1
+            writeArgs.append((data, characteristic))
+        }
+
+        // MARK: - restartScanning()
+
+        var restartScanningCallCount = 0
+
+        func restartScanning() {
+            restartScanningCallCount += 1
+        }
+
+        // MARK: - stopScanning()
+
+        var stopScanningCallCount = 0
+
+        func stopScanning() {
+            stopScanningCallCount += 1
+        }
+
+        // MARK: - cancelConnection()
+
+        var cancelConnectionCallCount = 0
+
+        func cancelConnection() {
+            cancelConnectionCallCount += 1
+        }
+    }
+#endif

--- a/companion/ChessBoard/Tests/BoardConnectionTests.swift
+++ b/companion/ChessBoard/Tests/BoardConnectionTests.swift
@@ -170,4 +170,16 @@ final class BoardConnectionTests: XCTestCase {
         board.submitMove(longMove)
         XCTAssertNotNil(board.lastCommandResult)
     }
+
+    func testConfigureAndStartWritesCorrectBytes() {
+        let transport = MockTransport()
+        let board = BoardConnection(transport: transport)
+        board.connectionState = .ready
+
+        board.configureAndStart(white: .human, black: .remote)
+
+        XCTAssertEqual(transport.writeCallCount, 1)
+        XCTAssertEqual(transport.writeArgs[0].data, Data([0x00, 0x01]))
+        XCTAssertEqual(transport.writeArgs[0].characteristic, GATT.startGame)
+    }
 }


### PR DESCRIPTION
## Summary

Introduces `MockTransport`, a `#if DEBUG` test double conforming to `BoardTransport` that records all write and lifecycle calls. The old nil-transport convenience init on `BoardConnection` is replaced with one that creates a `MockTransport`, giving previews and tests a real transport path instead of a no-op nil. Includes a new test verifying that `configureAndStart` encodes the correct player-type bytes to the correct GATT characteristic.

## Decisions & callouts

- `MockTransport` follows the existing `MockLichessAPI` pattern: stored call-count and argument-array properties, no behavior. This keeps it simple and avoids test brittleness from mock frameworks.
- The convenience init replacement is a drop-in with identical signature and defaults — no preview or test call sites needed updating.