### PR TITLE
refactor(companion): replace nil-transport previews with MockTransport injection

### DIFF
--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -74,27 +74,6 @@ class BoardConnection {
         transport.owner = self
     }
 
-    #if DEBUG
-        /// Creates a BoardConnection with pre-set state and no BLE transport.
-        /// Commands are no-ops (transport is nil). For use in #Preview macros.
-        init(
-            connectionState: ConnectionState = .ready,
-            gameStatus: GameStatus = .idle,
-            currentPosition: String? = nil,
-            lastCommandResult: CommandResult? = nil,
-            whitePlayerType: PlayerType? = .human,
-            blackPlayerType: PlayerType? = .remote
-        ) {
-            self.transport = nil
-            self.connectionState = connectionState
-            self.gameStatus = gameStatus
-            self.currentPosition = currentPosition
-            self.lastCommandResult = lastCommandResult
-            self.whitePlayerType = whitePlayerType
-            self.blackPlayerType = blackPlayerType
-        }
-    #endif
-
     /// The human player's color (nil if both or neither are human).
     var humanColor: Turn? {
         switch (whitePlayerType, blackPlayerType) {

--- a/companion/ChessBoard/Sources/BLE/BoardConnection.swift
+++ b/companion/ChessBoard/Sources/BLE/BoardConnection.swift
@@ -66,7 +66,7 @@ class BoardConnection {
     /// AI level to pass to LichessService.start() once the game reaches inProgress.
     var pendingLichessLevel: Int?
 
-    private var transport: BoardTransport?
+    private let transport: BoardTransport
 
     /// Production initializer. Callers must provide the transport explicitly.
     init(transport: BoardTransport) {
@@ -113,7 +113,7 @@ class BoardConnection {
         blackPlayerType = black
         lastCommandResult = nil
 
-        transport?.write(
+        transport.write(
             Data([white.rawValue, black.rawValue]),
             to: GATT.startGame
         )
@@ -124,7 +124,7 @@ class BoardConnection {
     /// Wire format: `[action: u8 (0x00 = resign), color: u8]`
     func resign(color: Turn) {
         lastCommandResult = nil
-        transport?.write(Data([0x00, color.rawValue]), to: GATT.matchControl)
+        transport.write(Data([0x00, color.rawValue]), to: GATT.matchControl)
     }
 
     /// Sends a cancel/abort command via Match Control.
@@ -132,7 +132,7 @@ class BoardConnection {
     /// Wire format: `[action: u8 (0x01 = cancel)]`
     func cancelGame() {
         lastCommandResult = nil
-        transport?.write(Data([0x01]), to: GATT.matchControl)
+        transport.write(Data([0x01]), to: GATT.matchControl)
     }
 
     /// Sends a move to the board.
@@ -144,7 +144,7 @@ class BoardConnection {
         lastCommandResult = nil
         var data = Data([UInt8(bytes.count)])
         data.append(contentsOf: bytes)
-        transport?.write(data, to: GATT.submitMove)
+        transport.write(data, to: GATT.submitMove)
     }
 
     /// Handles a move played notification from the board.
@@ -176,19 +176,19 @@ class BoardConnection {
     }
 
     func restartScanning() {
-        transport?.restartScanning()
+        transport.restartScanning()
     }
 
     func connectionTimedOut() {
         switch connectionState {
         case .scanning:
-            transport?.stopScanning()
+            transport.stopScanning()
             connectionState = .notFound
         case .connecting:
-            transport?.cancelConnection()
+            transport.cancelConnection()
             connectionState = .connectionFailed
         case .discoveringServices:
-            transport?.cancelConnection()
+            transport.cancelConnection()
             connectionState = .setupFailed
         default:
             break

--- a/companion/ChessBoard/Sources/BLE/MockBoard.swift
+++ b/companion/ChessBoard/Sources/BLE/MockBoard.swift
@@ -1,0 +1,25 @@
+#if DEBUG
+    import SwiftUI
+
+    /// A PreviewModifier that creates a MockTransport-backed BoardConnection
+    /// and injects it into the environment.
+    struct MockBoard: PreviewModifier {
+        var connectionState: ConnectionState = .ready
+        var gameStatus: GameStatus = .idle
+        var currentPosition: String? = nil
+        var lastCommandResult: CommandResult? = nil
+        var whitePlayerType: PlayerType? = .human
+        var blackPlayerType: PlayerType? = .remote
+
+        func body(content: Content, context: Void) -> some View {
+            let board = BoardConnection(transport: MockTransport())
+            board.connectionState = connectionState
+            board.gameStatus = gameStatus
+            board.currentPosition = currentPosition
+            board.lastCommandResult = lastCommandResult
+            board.whitePlayerType = whitePlayerType
+            board.blackPlayerType = blackPlayerType
+            return content.environment(board)
+        }
+    }
+#endif

--- a/companion/ChessBoard/Sources/BLE/MockTransport.swift
+++ b/companion/ChessBoard/Sources/BLE/MockTransport.swift
@@ -1,0 +1,45 @@
+#if DEBUG
+    import CoreBluetooth
+    import Foundation
+
+    /// A mock BoardTransport that records all write and lifecycle calls.
+    /// Available in DEBUG builds for use in previews and tests.
+    @MainActor
+    final class MockTransport: BoardTransport {
+        weak var owner: BoardConnection?
+
+        // MARK: - write(_:to:)
+
+        var writeCallCount = 0
+        var writeArgs: [(data: Data, characteristic: CBUUID)] = []
+
+        func write(_ data: Data, to characteristic: CBUUID) {
+            writeCallCount += 1
+            writeArgs.append((data, characteristic))
+        }
+
+        // MARK: - restartScanning()
+
+        var restartScanningCallCount = 0
+
+        func restartScanning() {
+            restartScanningCallCount += 1
+        }
+
+        // MARK: - stopScanning()
+
+        var stopScanningCallCount = 0
+
+        func stopScanning() {
+            stopScanningCallCount += 1
+        }
+
+        // MARK: - cancelConnection()
+
+        var cancelConnectionCallCount = 0
+
+        func cancelConnection() {
+            cancelConnectionCallCount += 1
+        }
+    }
+#endif

--- a/companion/ChessBoard/Sources/Views/ActiveGameView.swift
+++ b/companion/ChessBoard/Sources/Views/ActiveGameView.swift
@@ -78,46 +78,38 @@ struct ActiveGameView: View {
 }
 
 #if DEBUG
-    #Preview("Awaiting Pieces") {
+    #Preview(
+        "Awaiting Pieces",
+        traits: .modifier(MockBoard(gameStatus: .awaitingPieces))
+    ) {
         NavigationStack { ActiveGameView() }
-            .environment(
-                BoardConnection(
-                    gameStatus: .awaitingPieces
-                )
-            )
     }
-    #Preview("In Progress") {
-        NavigationStack { ActiveGameView() }
-            .environment(
-                BoardConnection(
-                    gameStatus: .inProgress,
-                    currentPosition:
-                        "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
-                )
+    #Preview(
+        "In Progress",
+        traits: .modifier(
+            MockBoard(
+                gameStatus: .inProgress,
+                currentPosition:
+                    "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
             )
+        )
+    ) {
+        NavigationStack { ActiveGameView() }
     }
-    #Preview("Checkmate") {
+    #Preview(
+        "Checkmate",
+        traits: .modifier(MockBoard(gameStatus: .checkmate(loser: .black)))
+    ) {
         NavigationStack { ActiveGameView() }
-            .environment(
-                BoardConnection(
-                    gameStatus: .checkmate(loser: .black)
-                )
-            )
     }
-    #Preview("Resigned") {
+    #Preview(
+        "Resigned",
+        traits: .modifier(MockBoard(gameStatus: .resigned(color: .white)))
+    ) {
         NavigationStack { ActiveGameView() }
-            .environment(
-                BoardConnection(
-                    gameStatus: .resigned(color: .white)
-                )
-            )
     }
-    #Preview("Stalemate") {
+    #Preview("Stalemate", traits: .modifier(MockBoard(gameStatus: .stalemate)))
+    {
         NavigationStack { ActiveGameView() }
-            .environment(
-                BoardConnection(
-                    gameStatus: .stalemate
-                )
-            )
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/ContentView.swift
+++ b/companion/ChessBoard/Sources/Views/ContentView.swift
@@ -19,20 +19,19 @@ struct ContentView: View {
 }
 
 #if DEBUG
-    #Preview("Ready - New Game") {
+    #Preview("Ready - New Game", traits: .modifier(MockBoard())) {
         ContentView()
-            .environment(BoardConnection(connectionState: .ready))
     }
-    #Preview("Scanning") {
+    #Preview(
+        "Scanning",
+        traits: .modifier(MockBoard(connectionState: .scanning))
+    ) {
         ContentView()
-            .environment(BoardConnection(connectionState: .scanning))
     }
-    #Preview("In Progress") {
+    #Preview(
+        "In Progress",
+        traits: .modifier(MockBoard(gameStatus: .inProgress))
+    ) {
         ContentView()
-            .environment(
-                BoardConnection(
-                    gameStatus: .inProgress
-                )
-            )
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/NewGameView.swift
+++ b/companion/ChessBoard/Sources/Views/NewGameView.swift
@@ -258,18 +258,10 @@ struct NewGameView: View {
 }
 
 #if DEBUG
-    #Preview("Idle") {
+    #Preview("Idle", traits: .modifier(MockBoard())) {
         NavigationStack { NewGameView() }
-            .environment(BoardConnection(connectionState: .ready))
     }
-    #Preview("Lichess Remote") {
+    #Preview("Lichess Remote", traits: .modifier(MockBoard())) {
         NavigationStack { NewGameView() }
-            .environment(
-                BoardConnection(
-                    connectionState: .ready,
-                    whitePlayerType: .human,
-                    blackPlayerType: .remote
-                )
-            )
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/ScanView.swift
+++ b/companion/ChessBoard/Sources/Views/ScanView.swift
@@ -94,26 +94,34 @@ struct ScanView: View {
 }
 
 #if DEBUG
-    #Preview("Scanning") {
+    #Preview(
+        "Scanning",
+        traits: .modifier(MockBoard(connectionState: .scanning))
+    ) {
         NavigationStack { ScanView() }
-            .environment(BoardConnection(connectionState: .scanning))
     }
-    #Preview("Not Found") {
+    #Preview(
+        "Not Found",
+        traits: .modifier(MockBoard(connectionState: .notFound))
+    ) {
         NavigationStack { ScanView() }
-            .environment(BoardConnection(connectionState: .notFound))
     }
-    #Preview("Connection Failed") {
+    #Preview(
+        "Connection Failed",
+        traits: .modifier(MockBoard(connectionState: .connectionFailed))
+    ) {
         NavigationStack { ScanView() }
-            .environment(
-                BoardConnection(connectionState: .connectionFailed)
-            )
     }
-    #Preview("Setup Failed") {
+    #Preview(
+        "Setup Failed",
+        traits: .modifier(MockBoard(connectionState: .setupFailed))
+    ) {
         NavigationStack { ScanView() }
-            .environment(BoardConnection(connectionState: .setupFailed))
     }
-    #Preview("Powered Off") {
+    #Preview(
+        "Powered Off",
+        traits: .modifier(MockBoard(connectionState: .poweredOff))
+    ) {
         NavigationStack { ScanView() }
-            .environment(BoardConnection(connectionState: .poweredOff))
     }
 #endif

--- a/companion/ChessBoard/Tests/BoardConnectionTests.swift
+++ b/companion/ChessBoard/Tests/BoardConnectionTests.swift
@@ -150,4 +150,16 @@ final class BoardConnectionTests: XCTestCase {
         board.submitMove(longMove)
         XCTAssertNotNil(board.lastCommandResult)
     }
+
+    func testConfigureAndStartWritesCorrectBytes() {
+        let transport = MockTransport()
+        let board = BoardConnection(transport: transport)
+        board.connectionState = .ready
+
+        board.configureAndStart(white: .human, black: .remote)
+
+        XCTAssertEqual(transport.writeCallCount, 1)
+        XCTAssertEqual(transport.writeArgs[0].data, Data([0x00, 0x01]))
+        XCTAssertEqual(transport.writeArgs[0].characteristic, GATT.startGame)
+    }
 }

--- a/companion/ChessBoard/Tests/BoardConnectionTests.swift
+++ b/companion/ChessBoard/Tests/BoardConnectionTests.swift
@@ -5,167 +5,147 @@ import XCTest
 @MainActor
 final class BoardConnectionTests: XCTestCase {
     func testInitialState() {
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         XCTAssertEqual(board.connectionState, .ready)
         XCTAssertEqual(board.gameStatus, .idle)
         XCTAssertNil(board.lastCommandResult)
     }
 
     func testConfigureAndStartSetsPlayerTypes() {
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         board.configureAndStart(white: .human, black: .remote)
         XCTAssertEqual(board.whitePlayerType, .human)
         XCTAssertEqual(board.blackPlayerType, .remote)
     }
 
     func testConfigureAndStartGuardsNotReady() {
-        let board = BoardConnection(
-            connectionState: .scanning,
-            whitePlayerType: nil,
-            blackPlayerType: nil
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .scanning
         board.configureAndStart(white: .human, black: .remote)
         XCTAssertNil(board.whitePlayerType)
     }
 
     func testResignClearsLastCommandResult() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            lastCommandResult: CommandResult(
-                ok: true,
-                source: .startGame,
-                error: nil
-            )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.lastCommandResult = CommandResult(
+            ok: true,
+            source: .startGame,
+            error: nil
         )
         board.resign(color: .white)
         XCTAssertNil(board.lastCommandResult)
     }
 
     func testHumanColor() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            whitePlayerType: .human,
-            blackPlayerType: .remote
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.whitePlayerType = .human
+        board.blackPlayerType = .remote
         XCTAssertEqual(board.humanColor, .white)
     }
 
     func testHumanColorBothHuman() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            whitePlayerType: .human,
-            blackPlayerType: .human
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.whitePlayerType = .human
+        board.blackPlayerType = .human
         XCTAssertNil(board.humanColor)
     }
 
     func testConnectionTimedOutFromScanning() {
-        let board = BoardConnection(connectionState: .scanning)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .scanning
         board.connectionTimedOut()
         XCTAssertEqual(board.connectionState, .notFound)
     }
 
     func testConnectionTimedOutFromConnecting() {
-        let board = BoardConnection(connectionState: .connecting)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .connecting
         board.connectionTimedOut()
         XCTAssertEqual(board.connectionState, .connectionFailed)
     }
 
     func testConnectionTimedOutFromDiscovering() {
-        let board = BoardConnection(
-            connectionState: .discoveringServices
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .discoveringServices
         board.connectionTimedOut()
         XCTAssertEqual(board.connectionState, .setupFailed)
     }
 
     func testResignColorAfterReconnect() {
-        // Simulate fresh app start: player types are nil, game still in progress on firmware
-        let board = BoardConnection(
-            connectionState: .ready,
-            gameStatus: .inProgress,
-            whitePlayerType: nil,
-            blackPlayerType: nil
-        )
-        // Before player types are read from firmware: no resign available
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.gameStatus = .inProgress
         XCTAssertNil(board.resignColor)
 
-        // Simulate BLE transport reading player types from firmware
         board.whitePlayerType = .human
         board.blackPlayerType = .remote
-
-        // Now resign should work — human is white
         XCTAssertEqual(board.resignColor, .white)
     }
 
     func testResignColorHumanVsHuman() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            gameStatus: .inProgress,
-            currentPosition:
-                "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
-            whitePlayerType: .human,
-            blackPlayerType: .human
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.gameStatus = .inProgress
+        board.currentPosition =
+            "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+        board.whitePlayerType = .human
+        board.blackPlayerType = .human
         XCTAssertEqual(board.resignColor, .black)
     }
 
     func testResignColorHumanVsHumanNoPosition() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            gameStatus: .inProgress,
-            whitePlayerType: .human,
-            blackPlayerType: .human
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.gameStatus = .inProgress
+        board.whitePlayerType = .human
+        board.blackPlayerType = .human
         XCTAssertNil(board.resignColor)
     }
 
     func testResignColorNilWhenPlayersUnset() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            gameStatus: .inProgress,
-            whitePlayerType: nil,
-            blackPlayerType: nil
-        )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.gameStatus = .inProgress
         XCTAssertNil(board.resignColor)
     }
 
     func testCancelGameClearsLastCommandResult() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            lastCommandResult: CommandResult(
-                ok: true,
-                source: .startGame,
-                error: nil
-            )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.lastCommandResult = CommandResult(
+            ok: true,
+            source: .startGame,
+            error: nil
         )
         board.cancelGame()
         XCTAssertNil(board.lastCommandResult)
     }
 
     func testSubmitMoveClearsLastCommandResult() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            lastCommandResult: CommandResult(
-                ok: false,
-                source: .startGame,
-                error: nil
-            )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.lastCommandResult = CommandResult(
+            ok: false,
+            source: .startGame,
+            error: nil
         )
         board.submitMove("e2e4")
         XCTAssertNil(board.lastCommandResult)
     }
 
     func testSubmitMoveTooLongIsIgnored() {
-        let board = BoardConnection(
-            connectionState: .ready,
-            lastCommandResult: CommandResult(
-                ok: true,
-                source: .startGame,
-                error: nil
-            )
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
+        board.lastCommandResult = CommandResult(
+            ok: true,
+            source: .startGame,
+            error: nil
         )
-        // A string longer than 255 bytes must not clear lastCommandResult
         let longMove = String(repeating: "a", count: 256)
         board.submitMove(longMove)
         XCTAssertNotNil(board.lastCommandResult)

--- a/companion/ChessBoard/Tests/LichessServiceTests.swift
+++ b/companion/ChessBoard/Tests/LichessServiceTests.swift
@@ -57,7 +57,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testBoardMovePlayedForwardsHumanMoves() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -80,7 +81,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testBoardMovePlayedIgnoresAIMoves() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -103,7 +105,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testBoardMovePlayedIgnoresWhenNotActive() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -121,7 +124,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testBoardMovePlayedIgnoresWhenNoGameId() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -144,7 +148,8 @@ final class LichessServiceTests: XCTestCase {
         api.streamEvents = [
             .gameState(moves: "e2e4 e7e5", status: "mate", winner: "white")
         ]
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -170,7 +175,8 @@ final class LichessServiceTests: XCTestCase {
         api.streamEvents = [
             .gameState(moves: "e2e4", status: "resign", winner: "white")
         ]
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -189,7 +195,8 @@ final class LichessServiceTests: XCTestCase {
         api.streamEvents = [
             .gameState(moves: "e2e4 e7e5", status: "stalemate", winner: nil)
         ]
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -209,7 +216,8 @@ final class LichessServiceTests: XCTestCase {
         let api = MockLichessAPI()
         api.challengeAIResult = .success("new-game-42")
         api.streamEvents = []
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -228,7 +236,8 @@ final class LichessServiceTests: XCTestCase {
         }
         let api = MockLichessAPI()
         api.challengeAIResult = .failure(FakeError())
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -246,7 +255,8 @@ final class LichessServiceTests: XCTestCase {
     func testStopCancelsStreamAndResigns() async {
         let api = MockLichessAPI()
         api.streamEvents = []
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -271,7 +281,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testStopWhenNotActiveDoesNotResign() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,
@@ -289,7 +300,8 @@ final class LichessServiceTests: XCTestCase {
 
     func testEchoSuppressionHumanIsBlack() async {
         let api = MockLichessAPI()
-        let board = BoardConnection(connectionState: .ready)
+        let board = BoardConnection(transport: MockTransport())
+        board.connectionState = .ready
         let service = LichessService(
             api: api,
             board: board,

--- a/companion/ChessBoard/Tests/LichessServiceTests.swift
+++ b/companion/ChessBoard/Tests/LichessServiceTests.swift
@@ -165,9 +165,8 @@ final class LichessServiceTests: XCTestCase {
             service.isActive,
             "Service should be inactive after terminal gameState"
         )
-        // board.cancelGame() should have been called — verify via lastCommandResult
-        // (cancelGame calls transport?.write but transport is nil in tests;
-        //  we verify the service's isActive is false as the primary signal)
+        // board.cancelGame() should have been called — verify via isActive
+        // (cancelGame writes through MockTransport; isActive is the primary signal)
     }
 
     func testResignGameStateTriggersCancelGame() async {

--- a/docs/specs/2026-04-08-companion-preview-support-design.md
+++ b/docs/specs/2026-04-08-companion-preview-support-design.md
@@ -2,471 +2,78 @@
 
 ## Overview
 
-The companion app cannot render any view in `#Preview` macros or run meaningfully in the iOS Simulator because every view depends on `BoardConnection`, which unconditionally creates a `CBCentralManager` on init. This design extracts a `BoardTransport` protocol from the BLE delegate, folds the WiFi/Lichess manager state into `BoardConnection`, and adds a `#if DEBUG` initializer that skips BLE -- enabling `#Preview` macros and Simulator usage while improving the overall architecture.
+The companion app cannot render any view in `#Preview` macros or run meaningfully in the iOS Simulator because every view depends on `BoardConnection`, which unconditionally creates a `CBCentralManager` on init. This design extracts a `BoardTransport` protocol to separate BLE I/O from application state, consolidates scattered manager state into `BoardConnection`, and introduces a mock transport for previews and tests.
 
 ## Goals
 
-- All four views (`ContentView`, `ScanView`, `NewGameView`, `ActiveGameView`) render in `#Preview` macros with representative states (scanning, connection failures, ready/idle, in-progress game, terminal states, WiFi connecting/failed, Lichess validating, etc.).
-- The app launches in the Simulator with a mock board connection showing `NewGameView` instead of being stuck on `ScanView`.
-- Views continue to use `@Environment(BoardConnection.self)` -- no view-layer protocol abstraction, no existential types, no observation-tracking risks.
-- The production BLE code path is preserved exactly (BLE starts on init, same timing).
-- Existing model tests (`GameStateTests`, `WifiStatusTests`, etc.) continue to pass without modification.
+- All views render in `#Preview` macros with representative states.
+- The app launches in the Simulator with a mock board connection instead of blocking on BLE scanning.
+- Views continue to use `@Environment(BoardConnection.self)` -- no view-layer protocol abstraction, no existential types.
+- The production BLE code path is preserved exactly.
+- Existing model tests continue to pass without modification.
 
 ## Non-Goals
 
-- Fully functional BLE simulation (replaying recorded BLE traffic, simulating board responses to commands).
-- Unit testing of view logic (e.g., verifying that tapping "Start Game" calls `configureAndStart`).
-- Abstracting `KeychainStore` or `UserDefaults` for preview isolation.
-- Making `BoardTransport` generic/reusable for other BLE devices -- this is a single-purpose app.
+- Fully functional BLE simulation (replaying recorded BLE traffic, simulating board responses).
+- Unit testing of view logic.
+- Abstracting keychain or user defaults for preview isolation.
 
 ## Architecture
-
-Three structural changes work together:
-
-1. **Extract `BoardTransport` protocol** -- the current private `BLEDelegate` class is extracted into its own file as `BLETransport`, conforming to a `BoardTransport` protocol. This is the single abstraction boundary; it separates CoreBluetooth I/O from application state management.
-2. **Fold `WifiManager` and `LichessManager` into `BoardConnection`** -- their observable status properties and command methods move into `BoardConnection` directly. Their CoreBluetooth references (`CBPeripheral`, `CBCharacteristic`) move into `BLETransport`. This eliminates two classes.
-3. **Add `#if DEBUG` initializer** -- a second initializer on `BoardConnection` accepts pre-set state and creates no transport. The production `init()` creates a `BLETransport` and starts scanning immediately, preserving current behavior exactly.
 
 ```
 ┌─────────────────────────────────────────────────────┐
 │                       Views                          │
 │  @Environment(BoardConnection.self) private var board│
-│  Read: board.connectionState, board.wifiStatus, etc. │
-│  Write: board.configureAndStart(...), board.resign()  │
 └────────────────────────┬────────────────────────────┘
                          │
 ┌────────────────────────▼────────────────────────────┐
 │                  BoardConnection                     │
-│  @Observable class — single source of truth          │
-│  Owns all state: connectionState, gameState,         │
-│    wifiStatus, lichessStatus, lastCommandResult,     │
-│    whitePlayerType, blackPlayerType                  │
-│  Commands: configureAndStart, resign, configureWifi, │
-│    setLichessToken, restartScanning, connectionTimedOut│
-│  Delegates BLE I/O to transport via optional chaining │
+│  @Observable — single source of truth                │
+│  Owns all state, delegates I/O to transport          │
+│  Transport is non-optional (private let)             │
 └────────────────────────┬────────────────────────────┘
                          │ BoardTransport protocol
 ┌────────────────────────▼────────────────────────────┐
-│  BLETransport (production only)                      │
+│  BLETransport (production)                           │
 │  CBCentralManager + CBPeripheral delegates           │
 │  Calls back via weak owner: BoardConnection?         │
-│  Owns all CBCharacteristic refs                      │
+├─────────────────────────────────────────────────────┤
+│  MockTransport (#if DEBUG)                           │
+│  Records write calls + lifecycle calls               │
+│  Used in previews (via MockBoard) and tests          │
 └─────────────────────────────────────────────────────┘
 ```
 
-## BoardTransport Protocol
+### BoardTransport
 
-Defines the narrow set of operations that vary between real BLE and no-op (preview/simulator). Located in `Sources/BLE/BoardTransport.swift`.
+Minimal protocol defining the operations that vary between real BLE and mock: writing data to a characteristic, restarting/stopping scans, and cancelling connections. Plus a weak `owner` back-reference for the transport to push state updates to `BoardConnection`.
 
-```swift
-import CoreBluetooth
+Everything else -- state decoding, state management, GATT characteristic routing, notification handling -- lives in the transport implementation and flows back through `owner`.
 
-/// Abstraction over the BLE transport layer.
-///
-/// The transport handles scanning, connecting, service/characteristic
-/// discovery, and raw writes. It calls back to BoardConnection via the
-/// weak `owner` reference when state changes occur.
-@MainActor
-protocol BoardTransport: AnyObject {
-    /// Weak back-reference to the owning BoardConnection.
-    /// Set immediately after init by BoardConnection.
-    var owner: BoardConnection? { get set }
+### BLETransport
 
-    /// Write raw data to the characteristic identified by the given GATT UUID.
-    func write(_ data: Data, to characteristic: CBUUID)
+Production implementation extracted from the existing BLE delegate code. Conforms to `BoardTransport` and the CoreBluetooth delegate protocols. All characteristic references and notification routing live here. Write errors are routed back to `BoardConnection` state properties via `owner`.
 
-    /// Stop current scan, clear peripheral state, and start a fresh scan.
-    func restartScanning()
+### BoardConnection
 
-    /// Stop an in-progress scan (called on timeout).
-    func stopScanning()
+Single `@Observable` source of truth for all app state. WiFi and Lichess status (previously in separate manager objects) are direct properties, flattening property access for views. All command methods encode data and call `transport.write(...)`.
 
-    /// Cancel the current peripheral connection (called on timeout).
-    func cancelConnection()
-}
-```
+Single initializer taking a `BoardTransport`. The transport is non-optional -- production callers pass `BLETransport`, previews and tests pass `MockTransport`. No nil transport path.
 
-The protocol surface is minimal: four operations. Everything else -- state decoding, state management, GATT characteristic routing, notification handling -- lives in `BLETransport` and flows back to `BoardConnection` via the `owner` back-reference.
+### MockTransport
 
-The transport uses `CBUUID` (from CoreBluetooth) in the `write` signature. `BoardTransport.swift` imports CoreBluetooth for this type. `BoardConnection.swift` also needs `import CoreBluetooth` because it references `GATT.*` constants (which are `CBUUID` values) when calling `transport?.write(data, to: GATT.whitePlayer)`. This is the same import the file already has today.
+`#if DEBUG`-gated class conforming to `BoardTransport`. Records call counts and arguments for each protocol method. Lives alongside production BLE code (not in test targets) because `#Preview` macros in source files need access.
 
-## BLETransport
+### MockBoard
 
-The current private `BLEDelegate` class is extracted into `Sources/BLE/BLETransport.swift` as a non-private class conforming to `BoardTransport`, `CBCentralManagerDelegate`, and `CBPeripheralDelegate`.
+`#if DEBUG`-gated `PreviewModifier` that creates a `MockTransport`-backed `BoardConnection`, sets requested state properties, and injects it into the SwiftUI environment. Defaults mirror the common preview case. Views use it via preview traits.
 
-The implementation is a mechanical extraction of the existing `BLEDelegate` code with two changes:
+### Simulator Support
 
-1. **WiFi/Lichess characteristic discovery and notification routing** -- currently delegated to `WifiManager.discoverCharacteristics(for:)` and `LichessManager.handleNotification(_:)` -- moves inline into `BLETransport`. The transport discovers WiFi/Lichess characteristics, subscribes to status notifications, and routes decoded updates directly to `owner?.wifiStatus` and `owner?.lichessStatus`.
+The app entry point uses a compile-time gate (`#if DEBUG && targetEnvironment(simulator)`) to pass `MockTransport` instead of `BLETransport`. Debug builds on physical devices still use real BLE.
 
-2. **WiFi/Lichess characteristic references** -- currently held by `WifiManager` and `LichessManager` -- move into `BLETransport`'s `characteristics` dictionary (which already stores game service characteristics). All characteristic writes go through the transport's existing `write(_:to:)` method.
-
-The transport remains GATT-aware (it references `GATT.*` constants to know which services to discover, which characteristics to subscribe to, etc.). Adding a new BLE characteristic requires adding the UUID to `GATT.swift` and adding handling in `BLETransport`'s delegate methods -- the same pattern as today.
-
-### Write error handling
-
-The current `BLEDelegate.peripheral(_:didWriteValueFor:error:)` routes write errors to `WifiManager.handleWriteError()` and `LichessManager.handleWriteError()`. With managers folded into `BoardConnection`, `BLETransport` routes write errors directly:
-
-```swift
-func peripheral(_ peripheral: CBPeripheral,
-                didWriteValueFor characteristic: CBCharacteristic,
-                error: Error?) {
-    guard error != nil else { return }
-    switch characteristic.uuid {
-    case GATT.wifiConfig:
-        owner?.wifiStatus = WifiStatus(state: .failed, message: "Write failed")
-    case GATT.lichessToken:
-        owner?.lichessStatus = LichessStatus(state: .failed, message: "Write failed")
-    default:
-        break
-    }
-}
-```
-
-## BoardConnection
-
-### State consolidation
+## Testing Strategy
 
-`WifiManager.status` and `LichessManager.status` become direct properties on `BoardConnection`:
+Tests construct `MockTransport` directly (not via `MockBoard`) and pass it to `BoardConnection`. This allows both state-based assertions and write-verification (asserting on recorded call counts and arguments).
 
-```swift
-@Observable
-class BoardConnection {
-    var connectionState: ConnectionState = .poweredOff
-    var gameState: GameState = .initial
-    var lastCommandResult: CommandResult?
-    var wifiStatus: WifiStatus = .disconnected
-    var lichessStatus: LichessStatus = .idle
-
-    private(set) var whitePlayerType: PlayerType?
-    private(set) var blackPlayerType: PlayerType?
-
-    private var transport: BoardTransport?
-
-    // ... methods ...
-}
-```
-
-Views access `board.wifiStatus` instead of `board.wifiManager.status`. This is one level of property access instead of two, which is simpler to reason about. Swift Observation tracks it identically (concrete `@Observable` class, no existentials).
-
-### Command methods
-
-`WifiManager.configure(ssid:password:authMode:)` becomes `BoardConnection.configureWifi(ssid:password:authMode:)`. `LichessManager.setToken(_:)` becomes `BoardConnection.setLichessToken(_:)`. The encode-and-write logic moves inline:
-
-```swift
-func configureWifi(ssid: String, password: String, authMode: WifiAuthMode) {
-    wifiStatus = WifiStatus(state: .connecting, message: "")
-    let config = WifiConfig(ssid: ssid, password: password, authMode: authMode)
-    transport?.write(config.encode(), to: GATT.wifiConfig)
-}
-
-func setLichessToken(_ token: String) {
-    let tokenBytes = Array(token.utf8)
-    guard tokenBytes.count <= 255 else { return }
-    lichessStatus = LichessStatus(state: .validating, message: "")
-    var data = Data([UInt8(tokenBytes.count)])
-    data.append(contentsOf: tokenBytes)
-    transport?.write(data, to: GATT.lichessToken)
-}
-```
-
-Existing command methods (`configureAndStart`, `resign`, `restartScanning`, `connectionTimedOut`) use optional chaining on `transport` where they previously called `delegate` methods.
-
-### Computed properties
-
-`humanColor` and `resignColor` remain unchanged -- they are pure functions of `whitePlayerType`, `blackPlayerType`, and `gameState.turn`.
-
-### Initializers
-
-```swift
-/// Production initializer. Creates BLETransport, which immediately
-/// starts CBCentralManager and begins scanning.
-init() {
-    let ble = BLETransport()
-    self.transport = ble
-    ble.owner = self
-}
-
-#if DEBUG
-/// Creates a BoardConnection with pre-set state and no BLE transport.
-/// Commands are no-ops (transport is nil). For use in #Preview macros
-/// and Simulator builds.
-init(
-    connectionState: ConnectionState = .ready,
-    gameState: GameState = .initial,
-    wifiStatus: WifiStatus = .disconnected,
-    lichessStatus: LichessStatus = .idle,
-    lastCommandResult: CommandResult? = nil,
-    whitePlayerType: PlayerType? = .human,
-    blackPlayerType: PlayerType? = .embedded
-) {
-    self.transport = nil
-    self.connectionState = connectionState
-    self.gameState = gameState
-    self.wifiStatus = wifiStatus
-    self.lichessStatus = lichessStatus
-    self.lastCommandResult = lastCommandResult
-    self.whitePlayerType = whitePlayerType
-    self.blackPlayerType = blackPlayerType
-}
-#endif
-```
-
-The `#if DEBUG` init provides defaults tuned for the common preview case: `.ready` connection with idle game, human-vs-engine. Every parameter is overridable.
-
-## View Changes
-
-### Environment injection
-
-All views continue to use:
-
-```swift
-@Environment(BoardConnection.self) private var board
-```
-
-No change. `@Observable` tracking works correctly because views access a concrete `@Observable` class.
-
-### NewGameView
-
-The only view with substantive changes. All references to `board.wifiManager` and `board.lichessManager` are replaced:
-
-| Before | After |
-|--------|-------|
-| `board.wifiManager.status` | `board.wifiStatus` |
-| `board.wifiManager.status.state` | `board.wifiStatus.state` |
-| `board.wifiManager.status.message` | `board.wifiStatus.message` |
-| `board.wifiManager.configure(ssid:password:authMode:)` | `board.configureWifi(ssid:password:authMode:)` |
-| `board.lichessManager.status` | `board.lichessStatus` |
-| `board.lichessManager.status.state` | `board.lichessStatus.state` |
-| `board.lichessManager.status.message` | `board.lichessStatus.message` |
-| `board.lichessManager.setToken(...)` | `board.setLichessToken(...)` |
-| `board.lichessManager.status = LichessStatus(...)` | `board.lichessStatus = LichessStatus(...)` |
-
-Additionally, `NewGameView` gets a `#if DEBUG` internal initializer that accepts initial player types. This is needed because the WiFi and Lichess form sections are gated behind a `needsLichess` computed property that checks whether either player is `.lichessAi` -- and those are local `@State` variables that default to `.human` / `.embedded`. Without this init, previews for WiFi/Lichess states would never render the relevant sections.
-
-```swift
-#if DEBUG
-init(whiteType: PlayerType = .human, blackType: PlayerType = .embedded) {
-    _whiteType = State(initialValue: whiteType)
-    _blackType = State(initialValue: blackType)
-}
-#endif
-```
-
-The existing parameterless `init` (implicit) remains the production entry point.
-
-### Other views
-
-`ContentView`, `ScanView`, and `ActiveGameView` have no changes to their existing code. They do not reference `wifiManager` or `lichessManager`.
-
-## ChessBoardApp
-
-Simulator gate to use the debug init:
-
-```swift
-@main
-struct ChessBoardApp: App {
-    @State private var board: BoardConnection = {
-        #if DEBUG && targetEnvironment(simulator)
-        BoardConnection(connectionState: .ready)
-        #else
-        BoardConnection()
-        #endif
-    }()
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-                .environment(board)
-        }
-    }
-}
-```
-
-The compound condition `DEBUG && targetEnvironment(simulator)` ensures the debug init is only used in debug builds on the Simulator. Release builds on the Simulator (e.g., for profiling) use the production init, and debug builds on a physical device use real BLE.
-
-## Preview Macros
-
-Each view file gets `#Preview` macros at the bottom, inside `#if DEBUG`, covering its key visual states. Previews use the debug init directly:
-
-**ScanView:**
-
-```swift
-#if DEBUG
-#Preview("Scanning") {
-    NavigationStack { ScanView() }
-        .environment(BoardConnection(connectionState: .scanning))
-}
-#Preview("Not Found") {
-    NavigationStack { ScanView() }
-        .environment(BoardConnection(connectionState: .notFound))
-}
-#Preview("Connection Failed") {
-    NavigationStack { ScanView() }
-        .environment(BoardConnection(connectionState: .connectionFailed))
-}
-#Preview("Setup Failed") {
-    NavigationStack { ScanView() }
-        .environment(BoardConnection(connectionState: .setupFailed))
-}
-#Preview("Powered Off") {
-    NavigationStack { ScanView() }
-        .environment(BoardConnection(connectionState: .poweredOff))
-}
-#endif
-```
-
-**NewGameView:**
-
-```swift
-#if DEBUG
-#Preview("Idle") {
-    NavigationStack { NewGameView() }
-        .environment(BoardConnection())
-}
-#Preview("WiFi Connecting") {
-    NavigationStack { NewGameView(whiteType: .human, blackType: .lichessAi) }
-        .environment(BoardConnection(
-            wifiStatus: WifiStatus(state: .connecting, message: "")
-        ))
-}
-#Preview("WiFi Connected") {
-    NavigationStack { NewGameView(whiteType: .human, blackType: .lichessAi) }
-        .environment(BoardConnection(
-            wifiStatus: WifiStatus(state: .connected, message: "")
-        ))
-}
-#Preview("WiFi Failed") {
-    NavigationStack { NewGameView(whiteType: .human, blackType: .lichessAi) }
-        .environment(BoardConnection(
-            wifiStatus: WifiStatus(state: .failed, message: "Connection timed out")
-        ))
-}
-#Preview("Lichess Validating") {
-    NavigationStack { NewGameView(whiteType: .human, blackType: .lichessAi) }
-        .environment(BoardConnection(
-            wifiStatus: WifiStatus(state: .connected, message: ""),
-            lichessStatus: LichessStatus(state: .validating, message: "")
-        ))
-}
-#Preview("Lichess Connected") {
-    NavigationStack { NewGameView(whiteType: .human, blackType: .lichessAi) }
-        .environment(BoardConnection(
-            wifiStatus: WifiStatus(state: .connected, message: ""),
-            lichessStatus: LichessStatus(state: .connected, message: "")
-        ))
-}
-#endif
-```
-
-**ActiveGameView:**
-
-```swift
-#if DEBUG
-#Preview("Awaiting Pieces") {
-    NavigationStack { ActiveGameView() }
-        .environment(BoardConnection(
-            gameState: GameState(status: .awaitingPieces, turn: .white)
-        ))
-}
-#Preview("In Progress") {
-    NavigationStack { ActiveGameView() }
-        .environment(BoardConnection(
-            gameState: GameState(status: .inProgress, turn: .white)
-        ))
-}
-#Preview("Checkmate") {
-    NavigationStack { ActiveGameView() }
-        .environment(BoardConnection(
-            gameState: GameState(status: .checkmate, turn: .black)
-        ))
-}
-#Preview("Resignation") {
-    NavigationStack { ActiveGameView() }
-        .environment(BoardConnection(
-            gameState: GameState(status: .resignation, turn: .white)
-        ))
-}
-#Preview("Stalemate") {
-    NavigationStack { ActiveGameView() }
-        .environment(BoardConnection(
-            gameState: GameState(status: .stalemate, turn: .white)
-        ))
-}
-#endif
-```
-
-**ContentView:**
-
-```swift
-#if DEBUG
-#Preview("Ready - New Game") {
-    ContentView()
-        .environment(BoardConnection())
-}
-#Preview("Scanning") {
-    ContentView()
-        .environment(BoardConnection(connectionState: .scanning))
-}
-#Preview("In Progress") {
-    ContentView()
-        .environment(BoardConnection(
-            gameState: GameState(status: .inProgress, turn: .white)
-        ))
-}
-#endif
-```
-
-## Test Changes
-
-### Deleted tests
-
-`WifiManagerTests.swift` and `LichessManagerTests.swift` are deleted. Their coverage is partially replaced by `BoardConnectionTests` and partially by the existing model decode tests. The old manager tests covered: (a) decoding notifications and updating status, (b) handling write errors, and (c) reset. Item (a) was largely redundant with `WifiStatusTests`/`LichessStatusTests` which test the decode logic directly. Items (b) and (c) tested trivial assignments. The BLE notification *routing* logic (matching characteristic UUIDs to the correct status property) moves into `BLETransport` and is not unit-tested -- it requires a real `CBPeripheral` to exercise. This is an acceptable tradeoff: the routing is a simple switch statement, and integration testing on a physical device covers it.
-
-### New tests
-
-`BoardConnectionTests.swift` tests `BoardConnection`'s command methods and state routing using the debug init (no transport, no BLE):
-
-```swift
-func testConfigureWifiSetsConnecting() {
-    let board = BoardConnection(connectionState: .ready)
-    board.configureWifi(ssid: "test", password: "pass", authMode: .wpa2)
-    XCTAssertEqual(board.wifiStatus.state, .connecting)
-}
-
-func testSetLichessTokenSetsValidating() {
-    let board = BoardConnection(connectionState: .ready)
-    board.setLichessToken("lip_abc123")
-    XCTAssertEqual(board.lichessStatus.state, .validating)
-}
-
-func testConfigureWifiNoOpWithoutTransport() {
-    let board = BoardConnection(connectionState: .ready)
-    board.configureWifi(ssid: "test", password: "pass", authMode: .wpa2)
-    // Status changes to .connecting (local state update happens)
-    // but no BLE write occurs (transport is nil)
-    XCTAssertEqual(board.wifiStatus.state, .connecting)
-}
-```
-
-The existing model decode tests (`WifiStatusTests`, `LichessStatusTests`, `GameStateTests`, `CommandResultTests`, `PlayerTypeTests`, `WifiConfigTests`) are unchanged.
-
-## Files Modified / Created / Deleted
-
-| Action | Path | Description |
-|--------|------|-------------|
-| Create | `Sources/BLE/BoardTransport.swift` | `BoardTransport` protocol definition |
-| Create | `Sources/BLE/BLETransport.swift` | CoreBluetooth implementation extracted from `BLEDelegate` |
-| Modify | `Sources/BLE/BoardConnection.swift` | Remove `BLEDelegate`, add transport property, fold WiFi/Lichess state and commands, add `#if DEBUG` init |
-| Delete | `Sources/BLE/WifiManager.swift` | State and commands folded into `BoardConnection` |
-| Delete | `Sources/BLE/LichessManager.swift` | State and commands folded into `BoardConnection` |
-| Modify | `Sources/App/ChessBoardApp.swift` | Add `#if DEBUG && targetEnvironment(simulator)` gate |
-| Modify | `Sources/Views/NewGameView.swift` | Replace `wifiManager`/`lichessManager` references, add `#if DEBUG` init for preview player types, add `#Preview` macros |
-| Modify | `Sources/Views/ScanView.swift` | Add `#Preview` macros |
-| Modify | `Sources/Views/ActiveGameView.swift` | Add `#Preview` macros |
-| Modify | `Sources/Views/ContentView.swift` | Add `#Preview` macros |
-| Create | `Tests/BoardConnectionTests.swift` | Tests for command methods and state transitions |
-| Delete | `Tests/WifiManagerTests.swift` | Replaced by `BoardConnectionTests` |
-| Delete | `Tests/LichessManagerTests.swift` | Replaced by `BoardConnectionTests` |
-| Modify | `project.yml` | No structural change needed (no Preview Content directory) |
-
-Unchanged: `GATT.swift`, all model files, `KeychainStore.swift`, all model test files.
+BLE notification routing in `BLETransport` is not unit-tested -- it requires a real `CBPeripheral`. This is acceptable: the routing is a simple switch and is covered by integration testing on a physical device.


### PR DESCRIPTION
## Summary

Replaces the `#if DEBUG` convenience init on `BoardConnection` (which set `transport = nil` for silent no-op commands) with a proper `MockTransport` conforming to `BoardTransport`. Previews now use a `MockBoard` `PreviewModifier` for environment injection, and tests construct `MockTransport` directly — enabling write verification that was previously impossible.

With all construction sites passing a real transport, `BoardConnection.transport` is made non-optional (`let` instead of `var?`), eliminating the silent no-op path entirely.

## References

- Spec: [`docs/specs/2026-04-08-companion-preview-support-design.md`](https://github.com/Jomik/unnamed-chess-project/blob/'"${HEAD_SHA}"'/docs/specs/2026-04-08-companion-preview-support-design.md) (this PR supersedes the spec's `#if DEBUG` convenience init section — spec may need updating)

## Decisions & callouts

- `MockTransport` lives in `Sources/BLE/` (not `Tests/`) because previews (`#Preview` macros in source files) need access to it. It is `#if DEBUG`-gated.
- `MockBoard` is a `PreviewModifier` rather than a helper function — this is the idiomatic SwiftUI approach for injecting environment dependencies into `#Preview` traits.
- The spec describes `BoardConnection.transport` as optional with optional-chaining commands. Now that `MockTransport` absorbs all calls, the optional is unnecessary and has been removed. The spec should be amended to reflect this.