### PR TITLE
refactor(companion): migrate iOS tests from XCTest to Swift Testing

### DIFF
--- a/companion/ChessBoard/Tests/BoardConnectionTests.swift
+++ b/companion/ChessBoard/Tests/BoardConnectionTests.swift
@@ -1,33 +1,33 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ChessBoard
 
-@MainActor
-final class BoardConnectionTests: XCTestCase {
-    func testInitialState() {
+@MainActor @Suite struct BoardConnectionTests {
+    @Test func initialState() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
-        XCTAssertEqual(board.connectionState, .ready)
-        XCTAssertEqual(board.gameStatus, .idle)
-        XCTAssertNil(board.lastCommandResult)
+        #expect(board.connectionState == .ready)
+        #expect(board.gameStatus == .idle)
+        #expect(board.lastCommandResult == nil)
     }
 
-    func testConfigureAndStartSetsPlayerTypes() {
+    @Test func configureAndStartSetsPlayerTypes() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.configureAndStart(white: .human, black: .remote)
-        XCTAssertEqual(board.whitePlayerType, .human)
-        XCTAssertEqual(board.blackPlayerType, .remote)
+        #expect(board.whitePlayerType == .human)
+        #expect(board.blackPlayerType == .remote)
     }
 
-    func testConfigureAndStartGuardsNotReady() {
+    @Test func configureAndStartGuardsNotReady() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .scanning
         board.configureAndStart(white: .human, black: .remote)
-        XCTAssertNil(board.whitePlayerType)
+        #expect(board.whitePlayerType == nil)
     }
 
-    func testResignClearsLastCommandResult() {
+    @Test func resignClearsLastCommandResult() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.lastCommandResult = CommandResult(
@@ -36,58 +36,58 @@ final class BoardConnectionTests: XCTestCase {
             error: nil
         )
         board.resign(color: .white)
-        XCTAssertNil(board.lastCommandResult)
+        #expect(board.lastCommandResult == nil)
     }
 
-    func testHumanColor() {
+    @Test func humanColor() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.whitePlayerType = .human
         board.blackPlayerType = .remote
-        XCTAssertEqual(board.humanColor, .white)
+        #expect(board.humanColor == .white)
     }
 
-    func testHumanColorBothHuman() {
+    @Test func humanColorBothHuman() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.whitePlayerType = .human
         board.blackPlayerType = .human
-        XCTAssertNil(board.humanColor)
+        #expect(board.humanColor == nil)
     }
 
-    func testConnectionTimedOutFromScanning() {
+    @Test func connectionTimedOutFromScanning() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .scanning
         board.connectionTimedOut()
-        XCTAssertEqual(board.connectionState, .notFound)
+        #expect(board.connectionState == .notFound)
     }
 
-    func testConnectionTimedOutFromConnecting() {
+    @Test func connectionTimedOutFromConnecting() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .connecting
         board.connectionTimedOut()
-        XCTAssertEqual(board.connectionState, .connectionFailed)
+        #expect(board.connectionState == .connectionFailed)
     }
 
-    func testConnectionTimedOutFromDiscovering() {
+    @Test func connectionTimedOutFromDiscovering() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .discoveringServices
         board.connectionTimedOut()
-        XCTAssertEqual(board.connectionState, .setupFailed)
+        #expect(board.connectionState == .setupFailed)
     }
 
-    func testResignColorAfterReconnect() {
+    @Test func resignColorAfterReconnect() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.gameStatus = .inProgress
-        XCTAssertNil(board.resignColor)
+        #expect(board.resignColor == nil)
 
         board.whitePlayerType = .human
         board.blackPlayerType = .remote
-        XCTAssertEqual(board.resignColor, .white)
+        #expect(board.resignColor == .white)
     }
 
-    func testResignColorHumanVsHuman() {
+    @Test func resignColorHumanVsHuman() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.gameStatus = .inProgress
@@ -95,26 +95,26 @@ final class BoardConnectionTests: XCTestCase {
             "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
         board.whitePlayerType = .human
         board.blackPlayerType = .human
-        XCTAssertEqual(board.resignColor, .black)
+        #expect(board.resignColor == .black)
     }
 
-    func testResignColorHumanVsHumanNoPosition() {
+    @Test func resignColorHumanVsHumanNoPosition() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.gameStatus = .inProgress
         board.whitePlayerType = .human
         board.blackPlayerType = .human
-        XCTAssertNil(board.resignColor)
+        #expect(board.resignColor == nil)
     }
 
-    func testResignColorNilWhenPlayersUnset() {
+    @Test func resignColorNilWhenPlayersUnset() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.gameStatus = .inProgress
-        XCTAssertNil(board.resignColor)
+        #expect(board.resignColor == nil)
     }
 
-    func testCancelGameClearsLastCommandResult() {
+    @Test func cancelGameClearsLastCommandResult() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.lastCommandResult = CommandResult(
@@ -123,10 +123,10 @@ final class BoardConnectionTests: XCTestCase {
             error: nil
         )
         board.cancelGame()
-        XCTAssertNil(board.lastCommandResult)
+        #expect(board.lastCommandResult == nil)
     }
 
-    func testSubmitMoveClearsLastCommandResult() {
+    @Test func submitMoveClearsLastCommandResult() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.lastCommandResult = CommandResult(
@@ -135,10 +135,10 @@ final class BoardConnectionTests: XCTestCase {
             error: nil
         )
         board.submitMove("e2e4")
-        XCTAssertNil(board.lastCommandResult)
+        #expect(board.lastCommandResult == nil)
     }
 
-    func testSubmitMoveTooLongIsIgnored() {
+    @Test func submitMoveTooLongIsIgnored() {
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
         board.lastCommandResult = CommandResult(
@@ -148,18 +148,18 @@ final class BoardConnectionTests: XCTestCase {
         )
         let longMove = String(repeating: "a", count: 256)
         board.submitMove(longMove)
-        XCTAssertNotNil(board.lastCommandResult)
+        #expect(board.lastCommandResult != nil)
     }
 
-    func testConfigureAndStartWritesCorrectBytes() {
+    @Test func configureAndStartWritesCorrectBytes() {
         let transport = MockTransport()
         let board = BoardConnection(transport: transport)
         board.connectionState = .ready
 
         board.configureAndStart(white: .human, black: .remote)
 
-        XCTAssertEqual(transport.writeCallCount, 1)
-        XCTAssertEqual(transport.writeArgs[0].data, Data([0x00, 0x01]))
-        XCTAssertEqual(transport.writeArgs[0].characteristic, GATT.startGame)
+        #expect(transport.writeCallCount == 1)
+        #expect(transport.writeArgs[0].data == Data([0x00, 0x01]))
+        #expect(transport.writeArgs[0].characteristic == GATT.startGame)
     }
 }

--- a/companion/ChessBoard/Tests/CommandResultTests.swift
+++ b/companion/ChessBoard/Tests/CommandResultTests.swift
@@ -1,108 +1,117 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ChessBoard
 
-final class CommandResultTests: XCTestCase {
-    func testDecodeStartGameSuccess() {
+@Suite struct CommandResultTests {
+    @Test func decodeStartGameSuccess() {
         let result = CommandResult.decode(Data([0x00, 0x00, 0x00]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: true, source: .startGame, error: nil)
+        #expect(
+            result == CommandResult(ok: true, source: .startGame, error: nil)
         )
     }
 
-    func testDecodeMatchControlSuccess() {
+    @Test func decodeMatchControlSuccess() {
         let result = CommandResult.decode(Data([0x00, 0x01, 0x00]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: true, source: .matchControl, error: nil)
+        #expect(
+            result == CommandResult(ok: true, source: .matchControl, error: nil)
         )
     }
 
-    func testDecodeSubmitMoveSuccess() {
+    @Test func decodeSubmitMoveSuccess() {
         let result = CommandResult.decode(Data([0x00, 0x02, 0x00]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: true, source: .submitMove, error: nil)
+        #expect(
+            result == CommandResult(ok: true, source: .submitMove, error: nil)
         )
     }
 
-    func testDecodeStartGameErrorGameAlreadyInProgress() {
+    @Test func decodeStartGameErrorGameAlreadyInProgress() {
         let result = CommandResult.decode(Data([0x01, 0x00, 0x00]))
-        XCTAssertEqual(
-            result,
-            CommandResult(
-                ok: false,
-                source: .startGame,
-                error: .gameAlreadyInProgress
-            )
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .startGame,
+                    error: .gameAlreadyInProgress
+                )
         )
     }
 
-    func testDecodeMatchControlErrorNoGameInProgress() {
+    @Test func decodeMatchControlErrorNoGameInProgress() {
         let result = CommandResult.decode(Data([0x01, 0x01, 0x01]))
-        XCTAssertEqual(
-            result,
-            CommandResult(
-                ok: false,
-                source: .matchControl,
-                error: .noGameInProgress
-            )
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .matchControl,
+                    error: .noGameInProgress
+                )
         )
     }
 
-    func testDecodeSubmitMoveErrorIllegalMove() {
+    @Test func decodeSubmitMoveErrorIllegalMove() {
         let result = CommandResult.decode(Data([0x01, 0x02, 0x03]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: false, source: .submitMove, error: .illegalMove)
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .submitMove,
+                    error: .illegalMove
+                )
         )
     }
 
-    func testDecodeSubmitMoveErrorNotYourTurn() {
+    @Test func decodeSubmitMoveErrorNotYourTurn() {
         let result = CommandResult.decode(Data([0x01, 0x02, 0x02]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: false, source: .submitMove, error: .notYourTurn)
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .submitMove,
+                    error: .notYourTurn
+                )
         )
     }
 
-    func testDecodeStartGameErrorInvalidCommand() {
+    @Test func decodeStartGameErrorInvalidCommand() {
         let result = CommandResult.decode(Data([0x01, 0x00, 0x05]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: false, source: .startGame, error: .invalidCommand)
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .startGame,
+                    error: .invalidCommand
+                )
         )
     }
 
-    func testDecodeErrorUnknownBoardError() {
+    @Test func decodeErrorUnknownBoardError() {
         // Unknown error code → BoardError is nil but result is still valid
         let result = CommandResult.decode(Data([0x01, 0x00, 0xFF]))
-        XCTAssertEqual(
-            result,
-            CommandResult(ok: false, source: .startGame, error: nil)
+        #expect(
+            result == CommandResult(ok: false, source: .startGame, error: nil)
         )
     }
 
-    func testDecodeCannotResignForRemotePlayer() {
+    @Test func decodeCannotResignForRemotePlayer() {
         let result = CommandResult.decode(Data([0x01, 0x01, 0x04]))
-        XCTAssertEqual(
-            result,
-            CommandResult(
-                ok: false,
-                source: .matchControl,
-                error: .cannotResignForRemotePlayer
-            )
+        #expect(
+            result
+                == CommandResult(
+                    ok: false,
+                    source: .matchControl,
+                    error: .cannotResignForRemotePlayer
+                )
         )
     }
 
-    func testDecodeTooShort() {
-        XCTAssertNil(CommandResult.decode(Data([0x00, 0x00])))
-        XCTAssertNil(CommandResult.decode(Data([0x00])))
-        XCTAssertNil(CommandResult.decode(Data()))
+    @Test func decodeTooShort() {
+        #expect(CommandResult.decode(Data([0x00, 0x00])) == nil)
+        #expect(CommandResult.decode(Data([0x00])) == nil)
+        #expect(CommandResult.decode(Data()) == nil)
     }
 
-    func testDecodeUnknownCommandSource() {
-        XCTAssertNil(CommandResult.decode(Data([0x00, 0xFF, 0x00])))
+    @Test func decodeUnknownCommandSource() {
+        #expect(CommandResult.decode(Data([0x00, 0xFF, 0x00])) == nil)
     }
 }

--- a/companion/ChessBoard/Tests/GameStatusTests.swift
+++ b/companion/ChessBoard/Tests/GameStatusTests.swift
@@ -1,87 +1,84 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ChessBoard
 
-final class GameStatusTests: XCTestCase {
-    func testDecodeIdle() {
-        XCTAssertEqual(GameStatus.decode(Data([0x00])), .idle)
+@Suite struct GameStatusTests {
+    @Test func decodeIdle() {
+        #expect(GameStatus.decode(Data([0x00])) == .idle)
     }
 
-    func testDecodeAwaitingPieces() {
-        XCTAssertEqual(GameStatus.decode(Data([0x01])), .awaitingPieces)
+    @Test func decodeAwaitingPieces() {
+        #expect(GameStatus.decode(Data([0x01])) == .awaitingPieces)
     }
 
-    func testDecodeInProgress() {
-        XCTAssertEqual(GameStatus.decode(Data([0x02])), .inProgress)
+    @Test func decodeInProgress() {
+        #expect(GameStatus.decode(Data([0x02])) == .inProgress)
     }
 
-    func testDecodeCheckmateWhiteLoser() {
-        XCTAssertEqual(
-            GameStatus.decode(Data([0x03, 0x00])),
-            .checkmate(loser: .white)
+    @Test func decodeCheckmateWhiteLoser() {
+        #expect(
+            GameStatus.decode(Data([0x03, 0x00])) == .checkmate(loser: .white)
         )
     }
 
-    func testDecodeCheckmateBlackLoser() {
-        XCTAssertEqual(
-            GameStatus.decode(Data([0x03, 0x01])),
-            .checkmate(loser: .black)
+    @Test func decodeCheckmateBlackLoser() {
+        #expect(
+            GameStatus.decode(Data([0x03, 0x01])) == .checkmate(loser: .black)
         )
     }
 
-    func testDecodeCheckmateMissingLoser() {
-        XCTAssertNil(GameStatus.decode(Data([0x03])))
+    @Test func decodeCheckmateMissingLoser() {
+        #expect(GameStatus.decode(Data([0x03])) == nil)
     }
 
-    func testDecodeCheckmateInvalidLoser() {
-        XCTAssertNil(GameStatus.decode(Data([0x03, 0xFF])))
+    @Test func decodeCheckmateInvalidLoser() {
+        #expect(GameStatus.decode(Data([0x03, 0xFF])) == nil)
     }
 
-    func testDecodeStalemate() {
-        XCTAssertEqual(GameStatus.decode(Data([0x04])), .stalemate)
+    @Test func decodeStalemate() {
+        #expect(GameStatus.decode(Data([0x04])) == .stalemate)
     }
 
-    func testDecodeResignedWhite() {
-        XCTAssertEqual(
-            GameStatus.decode(Data([0x05, 0x00])),
-            .resigned(color: .white)
+    @Test func decodeResignedWhite() {
+        #expect(
+            GameStatus.decode(Data([0x05, 0x00])) == .resigned(color: .white)
         )
     }
 
-    func testDecodeResignedBlack() {
-        XCTAssertEqual(
-            GameStatus.decode(Data([0x05, 0x01])),
-            .resigned(color: .black)
+    @Test func decodeResignedBlack() {
+        #expect(
+            GameStatus.decode(Data([0x05, 0x01])) == .resigned(color: .black)
         )
     }
 
-    func testDecodeResignedMissingColor() {
-        XCTAssertNil(GameStatus.decode(Data([0x05])))
+    @Test func decodeResignedMissingColor() {
+        #expect(GameStatus.decode(Data([0x05])) == nil)
     }
 
-    func testDecodeResignedInvalidColor() {
-        XCTAssertNil(GameStatus.decode(Data([0x05, 0xFF])))
+    @Test func decodeResignedInvalidColor() {
+        #expect(GameStatus.decode(Data([0x05, 0xFF])) == nil)
     }
 
-    func testDecodeInvalidTag() {
-        XCTAssertNil(GameStatus.decode(Data([0xFF])))
+    @Test func decodeInvalidTag() {
+        #expect(GameStatus.decode(Data([0xFF])) == nil)
     }
 
-    func testDecodeEmpty() {
-        XCTAssertNil(GameStatus.decode(Data()))
+    @Test func decodeEmpty() {
+        #expect(GameStatus.decode(Data()) == nil)
     }
 
-    func testIsTerminalFalseForNonTerminal() {
-        XCTAssertFalse(GameStatus.idle.isTerminal)
-        XCTAssertFalse(GameStatus.awaitingPieces.isTerminal)
-        XCTAssertFalse(GameStatus.inProgress.isTerminal)
+    @Test func isTerminalFalseForNonTerminal() {
+        #expect(!GameStatus.idle.isTerminal)
+        #expect(!GameStatus.awaitingPieces.isTerminal)
+        #expect(!GameStatus.inProgress.isTerminal)
     }
 
-    func testIsTerminalTrueForTerminal() {
-        XCTAssertTrue(GameStatus.checkmate(loser: .white).isTerminal)
-        XCTAssertTrue(GameStatus.checkmate(loser: .black).isTerminal)
-        XCTAssertTrue(GameStatus.stalemate.isTerminal)
-        XCTAssertTrue(GameStatus.resigned(color: .white).isTerminal)
-        XCTAssertTrue(GameStatus.resigned(color: .black).isTerminal)
+    @Test func isTerminalTrueForTerminal() {
+        #expect(GameStatus.checkmate(loser: .white).isTerminal)
+        #expect(GameStatus.checkmate(loser: .black).isTerminal)
+        #expect(GameStatus.stalemate.isTerminal)
+        #expect(GameStatus.resigned(color: .white).isTerminal)
+        #expect(GameStatus.resigned(color: .black).isTerminal)
     }
 }

--- a/companion/ChessBoard/Tests/LichessAPITests.swift
+++ b/companion/ChessBoard/Tests/LichessAPITests.swift
@@ -1,137 +1,137 @@
-import XCTest
+import Testing
 
 @testable import ChessBoard
 
 // MARK: - LichessAPITests
 
-final class LichessAPITests: XCTestCase {
+@Suite struct LichessAPITests {
     // MARK: - parseLine tests (via streamGame parsing logic)
     // We test parsing indirectly by feeding sample Lichess NDJSON responses
     // through a mock URLSession.
 
-    func testParseGameFullEvent() throws {
+    @Test func parseGameFullEvent() throws {
         let line = """
             {"type":"gameFull","id":"abc123","opponent":{"aiLevel":3},"state":{"moves":"e2e4 e7e5","status":"started"}}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameFull(let id, let initialMoves, let aiLevel) = event
         else {
-            XCTFail("Expected gameFull, got \(String(describing: event))")
+            Issue.record("Expected gameFull, got \(event)")
             return
         }
-        XCTAssertEqual(id, "abc123")
-        XCTAssertEqual(initialMoves, "e2e4 e7e5")
-        XCTAssertEqual(aiLevel, 3)
+        #expect(id == "abc123")
+        #expect(initialMoves == "e2e4 e7e5")
+        #expect(aiLevel == 3)
     }
 
-    func testParseGameFullEventNoMoves() throws {
+    @Test func parseGameFullEventNoMoves() throws {
         let line = """
             {"type":"gameFull","id":"xyz","opponent":{"aiLevel":1},"state":{"moves":"","status":"started"}}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameFull(let id, let initialMoves, let aiLevel) = event
         else {
-            XCTFail("Expected gameFull, got \(String(describing: event))")
+            Issue.record("Expected gameFull, got \(event)")
             return
         }
-        XCTAssertEqual(id, "xyz")
-        XCTAssertEqual(initialMoves, "")
-        XCTAssertEqual(aiLevel, 1)
+        #expect(id == "xyz")
+        #expect(initialMoves == "")
+        #expect(aiLevel == 1)
     }
 
-    func testParseGameFullEventMissingId() {
+    @Test func parseGameFullEventMissingId() {
         let line = """
             {"type":"gameFull","opponent":{"aiLevel":1},"state":{"moves":""}}
             """
         let event = parseLineForTest(line)
-        XCTAssertNil(event, "Should return nil when id is missing")
+        #expect(event == nil, "Should return nil when id is missing")
     }
 
-    func testParseGameFullEventMissingOpponent() {
+    @Test func parseGameFullEventMissingOpponent() throws {
         // When opponent key is absent, aiLevel defaults to 1
         let line = """
             {"type":"gameFull","id":"abc","state":{"moves":""}}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameFull(let id, _, let aiLevel) = event else {
-            XCTFail("Expected gameFull, got \(String(describing: event))")
+            Issue.record("Expected gameFull, got \(event)")
             return
         }
-        XCTAssertEqual(id, "abc")
-        XCTAssertEqual(aiLevel, 1)
+        #expect(id == "abc")
+        #expect(aiLevel == 1)
     }
 
-    func testParseGameStateEvent() {
+    @Test func parseGameStateEvent() throws {
         let line = """
             {"type":"gameState","moves":"e2e4 e7e5 g1f3","status":"started","winner":null}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameState(let moves, let status, let winner) = event else {
-            XCTFail("Expected gameState, got \(String(describing: event))")
+            Issue.record("Expected gameState, got \(event)")
             return
         }
-        XCTAssertEqual(moves, "e2e4 e7e5 g1f3")
-        XCTAssertEqual(status, "started")
-        XCTAssertNil(winner)
+        #expect(moves == "e2e4 e7e5 g1f3")
+        #expect(status == "started")
+        #expect(winner == nil)
     }
 
-    func testParseGameStateEventWithWinner() {
+    @Test func parseGameStateEventWithWinner() throws {
         let line = """
             {"type":"gameState","moves":"e2e4 e7e5","status":"mate","winner":"white"}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameState(let moves, let status, let winner) = event else {
-            XCTFail("Expected gameState, got \(String(describing: event))")
+            Issue.record("Expected gameState, got \(event)")
             return
         }
-        XCTAssertEqual(moves, "e2e4 e7e5")
-        XCTAssertEqual(status, "mate")
-        XCTAssertEqual(winner, "white")
+        #expect(moves == "e2e4 e7e5")
+        #expect(status == "mate")
+        #expect(winner == "white")
     }
 
-    func testParseGameStateMissingMoves() {
+    @Test func parseGameStateMissingMoves() {
         let line = """
             {"type":"gameState","status":"started"}
             """
         let event = parseLineForTest(line)
-        XCTAssertNil(event, "Should return nil when moves field is missing")
+        #expect(event == nil, "Should return nil when moves field is missing")
     }
 
-    func testParseGameStateMissingStatus() {
+    @Test func parseGameStateMissingStatus() {
         let line = """
             {"type":"gameState","moves":"e2e4"}
             """
         let event = parseLineForTest(line)
-        XCTAssertNil(event, "Should return nil when status field is missing")
+        #expect(event == nil, "Should return nil when status field is missing")
     }
 
-    func testParseUnknownType() {
+    @Test func parseUnknownType() {
         let line = """
             {"type":"ping"}
             """
         let event = parseLineForTest(line)
-        XCTAssertNil(event, "Should return nil for unknown event types")
+        #expect(event == nil, "Should return nil for unknown event types")
     }
 
-    func testParseEmptyString() {
-        XCTAssertNil(parseLineForTest(""))
+    @Test func parseEmptyString() {
+        #expect(parseLineForTest("") == nil)
     }
 
-    func testParseInvalidJSON() {
-        XCTAssertNil(parseLineForTest("not json"))
+    @Test func parseInvalidJSON() {
+        #expect(parseLineForTest("not json") == nil)
     }
 
-    func testParseGameFullMissingStateKey() {
+    @Test func parseGameFullMissingStateKey() throws {
         // State key absent → initialMoves defaults to ""
         let line = """
             {"type":"gameFull","id":"abc","opponent":{"aiLevel":2}}
             """
-        let event = parseLineForTest(line)
+        let event = try #require(parseLineForTest(line))
         guard case .gameFull(_, let initialMoves, _) = event else {
-            XCTFail("Expected gameFull")
+            Issue.record("Expected gameFull")
             return
         }
-        XCTAssertEqual(initialMoves, "")
+        #expect(initialMoves == "")
     }
 
     // MARK: - Helpers

--- a/companion/ChessBoard/Tests/LichessServiceTests.swift
+++ b/companion/ChessBoard/Tests/LichessServiceTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ChessBoard
 
@@ -51,11 +52,11 @@ final class MockLichessAPI: LichessAPIProtocol, @unchecked Sendable {
 
 // MARK: - LichessServiceTests
 
-@MainActor
-final class LichessServiceTests: XCTestCase {
+@MainActor @Suite(.serialized)
+struct LichessServiceTests {
     // MARK: - Echo suppression
 
-    func testBoardMovePlayedForwardsHumanMoves() async {
+    @Test func boardMovePlayedForwardsHumanMoves() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -75,11 +76,11 @@ final class LichessServiceTests: XCTestCase {
         // to schedule and complete the child Task.
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.makeMoveCallCount, 1)
-        XCTAssertEqual(api.makeMoveArgs.first?.uci, "e2e4")
+        #expect(api.makeMoveCallCount == 1)
+        #expect(api.makeMoveArgs.first?.uci == "e2e4")
     }
 
-    func testBoardMovePlayedIgnoresAIMoves() async {
+    @Test func boardMovePlayedIgnoresAIMoves() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -96,14 +97,13 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(
-            api.makeMoveCallCount,
-            0,
+        #expect(
+            api.makeMoveCallCount == 0,
             "AI echo must not be forwarded to Lichess"
         )
     }
 
-    func testBoardMovePlayedIgnoresWhenNotActive() async {
+    @Test func boardMovePlayedIgnoresWhenNotActive() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -119,10 +119,10 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.makeMoveCallCount, 0)
+        #expect(api.makeMoveCallCount == 0)
     }
 
-    func testBoardMovePlayedIgnoresWhenNoGameId() async {
+    @Test func boardMovePlayedIgnoresWhenNoGameId() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -138,12 +138,12 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.makeMoveCallCount, 0)
+        #expect(api.makeMoveCallCount == 0)
     }
 
     // MARK: - Terminal state handling
 
-    func testTerminalGameStateTriggersCancelGame() async {
+    @Test func terminalGameStateTriggersCancelGame() async {
         let api = MockLichessAPI()
         api.streamEvents = [
             .gameState(moves: "e2e4 e7e5", status: "mate", winner: "white")
@@ -161,15 +161,15 @@ final class LichessServiceTests: XCTestCase {
         // Give the stream task time to run
         try? await Task.sleep(for: .milliseconds(50))
 
-        XCTAssertFalse(
-            service.isActive,
+        #expect(
+            !service.isActive,
             "Service should be inactive after terminal gameState"
         )
         // board.cancelGame() should have been called — verify via isActive
         // (cancelGame writes through MockTransport; isActive is the primary signal)
     }
 
-    func testResignGameStateTriggersCancelGame() async {
+    @Test func resignGameStateTriggersCancelGame() async {
         let api = MockLichessAPI()
         api.streamEvents = [
             .gameState(moves: "e2e4", status: "resign", winner: "white")
@@ -186,10 +186,10 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(for: .milliseconds(50))
 
-        XCTAssertFalse(service.isActive)
+        #expect(!service.isActive)
     }
 
-    func testStalemateGameStateTriggersCancelGame() async {
+    @Test func stalemateGameStateTriggersCancelGame() async {
         let api = MockLichessAPI()
         api.streamEvents = [
             .gameState(moves: "e2e4 e7e5", status: "stalemate", winner: nil)
@@ -206,12 +206,12 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(for: .milliseconds(50))
 
-        XCTAssertFalse(service.isActive)
+        #expect(!service.isActive)
     }
 
     // MARK: - start() lifecycle
 
-    func testStartSetsGameId() async {
+    @Test func startSetsGameId() async {
         let api = MockLichessAPI()
         api.challengeAIResult = .success("new-game-42")
         api.streamEvents = []
@@ -225,11 +225,11 @@ final class LichessServiceTests: XCTestCase {
 
         await service.start(level: 2)
 
-        XCTAssertEqual(service.gameId, "new-game-42")
-        XCTAssertTrue(service.isActive)
+        #expect(service.gameId == "new-game-42")
+        #expect(service.isActive)
     }
 
-    func testStartSetsErrorOnAPIFailure() async {
+    @Test func startSetsErrorOnAPIFailure() async {
         struct FakeError: Error, LocalizedError {
             var errorDescription: String? { "Network error" }
         }
@@ -245,13 +245,13 @@ final class LichessServiceTests: XCTestCase {
 
         await service.start(level: 1)
 
-        XCTAssertFalse(service.isActive)
-        XCTAssertNotNil(service.error)
+        #expect(!service.isActive)
+        #expect(service.error != nil)
     }
 
     // MARK: - stop()
 
-    func testStopCancelsStreamAndResigns() async {
+    @Test func stopCancelsStreamAndResigns() async {
         let api = MockLichessAPI()
         api.streamEvents = []
         let board = BoardConnection(transport: MockTransport())
@@ -263,22 +263,22 @@ final class LichessServiceTests: XCTestCase {
         )
 
         await service.start(level: 1)
-        XCTAssertTrue(service.isActive)
+        #expect(service.isActive)
         let capturedGameId = service.gameId
 
         service.stop()
 
-        XCTAssertFalse(service.isActive)
-        XCTAssertNil(service.gameId)
+        #expect(!service.isActive)
+        #expect(service.gameId == nil)
 
         // Allow the resign Task to run
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.resignCallCount, 1)
-        XCTAssertEqual(api.resignArgs.first, capturedGameId)
+        #expect(api.resignCallCount == 1)
+        #expect(api.resignArgs.first == capturedGameId)
     }
 
-    func testStopWhenNotActiveDoesNotResign() async {
+    @Test func stopWhenNotActiveDoesNotResign() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -292,12 +292,12 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.resignCallCount, 0)
+        #expect(api.resignCallCount == 0)
     }
 
     // MARK: - Echo suppression with human as black
 
-    func testEchoSuppressionHumanIsBlack() async {
+    @Test func echoSuppressionHumanIsBlack() async {
         let api = MockLichessAPI()
         let board = BoardConnection(transport: MockTransport())
         board.connectionState = .ready
@@ -314,9 +314,8 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(
-            api.makeMoveCallCount,
-            0,
+        #expect(
+            api.makeMoveCallCount == 0,
             "White move must be suppressed when human is black"
         )
 
@@ -325,7 +324,7 @@ final class LichessServiceTests: XCTestCase {
 
         try? await Task.sleep(nanoseconds: 10_000_000)
 
-        XCTAssertEqual(api.makeMoveCallCount, 1)
-        XCTAssertEqual(api.makeMoveArgs.first?.uci, "e7e5")
+        #expect(api.makeMoveCallCount == 1)
+        #expect(api.makeMoveArgs.first?.uci == "e7e5")
     }
 }

--- a/companion/ChessBoard/Tests/PlayerTypeTests.swift
+++ b/companion/ChessBoard/Tests/PlayerTypeTests.swift
@@ -1,34 +1,35 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ChessBoard
 
-final class PlayerTypeTests: XCTestCase {
-    func testEncodeHuman() {
-        XCTAssertEqual(PlayerType.human.encode(), Data([0x00]))
+@Suite struct PlayerTypeTests {
+    @Test func encodeHuman() {
+        #expect(PlayerType.human.encode() == Data([0x00]))
     }
 
-    func testEncodeRemote() {
-        XCTAssertEqual(PlayerType.remote.encode(), Data([0x01]))
+    @Test func encodeRemote() {
+        #expect(PlayerType.remote.encode() == Data([0x01]))
     }
 
-    func testEncodedLengths() {
-        XCTAssertEqual(PlayerType.human.encode().count, 1)
-        XCTAssertEqual(PlayerType.remote.encode().count, 1)
+    @Test func encodedLengths() {
+        #expect(PlayerType.human.encode().count == 1)
+        #expect(PlayerType.remote.encode().count == 1)
     }
 
-    func testDecodeHuman() {
-        XCTAssertEqual(PlayerType.decode(Data([0x00])), .human)
+    @Test func decodeHuman() {
+        #expect(PlayerType.decode(Data([0x00])) == .human)
     }
 
-    func testDecodeRemote() {
-        XCTAssertEqual(PlayerType.decode(Data([0x01])), .remote)
+    @Test func decodeRemote() {
+        #expect(PlayerType.decode(Data([0x01])) == .remote)
     }
 
-    func testDecodeUnknown() {
-        XCTAssertNil(PlayerType.decode(Data([0xFF])))
+    @Test func decodeUnknown() {
+        #expect(PlayerType.decode(Data([0xFF])) == nil)
     }
 
-    func testDecodeEmpty() {
-        XCTAssertNil(PlayerType.decode(Data()))
+    @Test func decodeEmpty() {
+        #expect(PlayerType.decode(Data()) == nil)
     }
 }


### PR DESCRIPTION
## Summary

Migrates all 6 iOS companion app test files (71 tests) from XCTest to the Swift Testing framework. This is a mechanical 1:1 migration with no behavioral changes — `XCTestCase` classes become `@Suite` structs, `func testFoo()` becomes `@Test func foo()`, and XCTest assertions become `#expect`/`#require` macros.

## Decisions & callouts

- `LichessServiceTests` uses `@Suite(.serialized)` because its async tests rely on `Task.sleep` for timing coordination with fire-and-forget tasks — parallel execution could cause flaky failures.
- `MockLichessAPI` and `FakeError` are not test types and were intentionally left unchanged.
- In `LichessAPITests`, the `guard case` + `XCTFail` pattern was migrated to `try #require` (for optional unwrap) + `guard case` + `Issue.record` (for enum destructuring), since `#require` doesn't support direct enum pattern matching.