### PR TITLE
refactor(companion): replace MockBoard PreviewModifier with View extension

### DIFF
--- a/companion/ChessBoard/Sources/BLE/MockBoard.swift
+++ b/companion/ChessBoard/Sources/BLE/MockBoard.swift
@@ -1,17 +1,17 @@
 #if DEBUG
     import SwiftUI
 
-    /// A PreviewModifier that creates a MockTransport-backed BoardConnection
-    /// and injects it into the environment.
-    struct MockBoard: PreviewModifier {
-        var connectionState: ConnectionState = .ready
-        var gameStatus: GameStatus = .idle
-        var currentPosition: String? = nil
-        var lastCommandResult: CommandResult? = nil
-        var whitePlayerType: PlayerType? = .human
-        var blackPlayerType: PlayerType? = .remote
-
-        func body(content: Content, context: Void) -> some View {
+    extension View {
+        /// Creates a MockTransport-backed BoardConnection and injects it into
+        /// the environment. This is a convenience method for SwiftUI Previews.
+        func mockBoard(
+            connectionState: ConnectionState = .ready,
+            gameStatus: GameStatus = .idle,
+            currentPosition: String? = nil,
+            lastCommandResult: CommandResult? = nil,
+            whitePlayerType: PlayerType? = .human,
+            blackPlayerType: PlayerType? = .remote
+        ) -> some View {
             let board = BoardConnection(transport: MockTransport())
             board.connectionState = connectionState
             board.gameStatus = gameStatus
@@ -19,7 +19,7 @@
             board.lastCommandResult = lastCommandResult
             board.whitePlayerType = whitePlayerType
             board.blackPlayerType = blackPlayerType
-            return content.environment(board)
+            return self.environment(board)
         }
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/ActiveGameView.swift
+++ b/companion/ChessBoard/Sources/Views/ActiveGameView.swift
@@ -78,38 +78,28 @@ struct ActiveGameView: View {
 }
 
 #if DEBUG
-    #Preview(
-        "Awaiting Pieces",
-        traits: .modifier(MockBoard(gameStatus: .awaitingPieces))
-    ) {
+    #Preview("Awaiting Pieces") {
         NavigationStack { ActiveGameView() }
+            .mockBoard(gameStatus: .awaitingPieces)
     }
-    #Preview(
-        "In Progress",
-        traits: .modifier(
-            MockBoard(
+    #Preview("In Progress") {
+        NavigationStack { ActiveGameView() }
+            .mockBoard(
                 gameStatus: .inProgress,
                 currentPosition:
                     "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
             )
-        )
-    ) {
-        NavigationStack { ActiveGameView() }
     }
-    #Preview(
-        "Checkmate",
-        traits: .modifier(MockBoard(gameStatus: .checkmate(loser: .black)))
-    ) {
+    #Preview("Checkmate") {
         NavigationStack { ActiveGameView() }
+            .mockBoard(gameStatus: .checkmate(loser: .black))
     }
-    #Preview(
-        "Resigned",
-        traits: .modifier(MockBoard(gameStatus: .resigned(color: .white)))
-    ) {
+    #Preview("Resigned") {
         NavigationStack { ActiveGameView() }
+            .mockBoard(gameStatus: .resigned(color: .white))
     }
-    #Preview("Stalemate", traits: .modifier(MockBoard(gameStatus: .stalemate)))
-    {
+    #Preview("Stalemate") {
         NavigationStack { ActiveGameView() }
+            .mockBoard(gameStatus: .stalemate)
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/ContentView.swift
+++ b/companion/ChessBoard/Sources/Views/ContentView.swift
@@ -19,19 +19,16 @@ struct ContentView: View {
 }
 
 #if DEBUG
-    #Preview("Ready - New Game", traits: .modifier(MockBoard())) {
+    #Preview("Ready - New Game") {
         ContentView()
+            .mockBoard()
     }
-    #Preview(
-        "Scanning",
-        traits: .modifier(MockBoard(connectionState: .scanning))
-    ) {
+    #Preview("Scanning") {
         ContentView()
+            .mockBoard(connectionState: .scanning)
     }
-    #Preview(
-        "In Progress",
-        traits: .modifier(MockBoard(gameStatus: .inProgress))
-    ) {
+    #Preview("In Progress") {
         ContentView()
+            .mockBoard(gameStatus: .inProgress)
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/NewGameView.swift
+++ b/companion/ChessBoard/Sources/Views/NewGameView.swift
@@ -258,10 +258,12 @@ struct NewGameView: View {
 }
 
 #if DEBUG
-    #Preview("Idle", traits: .modifier(MockBoard())) {
+    #Preview("Idle") {
         NavigationStack { NewGameView() }
+            .mockBoard()
     }
-    #Preview("Lichess Remote", traits: .modifier(MockBoard())) {
+    #Preview("Lichess Remote") {
         NavigationStack { NewGameView() }
+            .mockBoard()
     }
 #endif

--- a/companion/ChessBoard/Sources/Views/ScanView.swift
+++ b/companion/ChessBoard/Sources/Views/ScanView.swift
@@ -94,34 +94,24 @@ struct ScanView: View {
 }
 
 #if DEBUG
-    #Preview(
-        "Scanning",
-        traits: .modifier(MockBoard(connectionState: .scanning))
-    ) {
+    #Preview("Scanning") {
         NavigationStack { ScanView() }
+            .mockBoard(connectionState: .scanning)
     }
-    #Preview(
-        "Not Found",
-        traits: .modifier(MockBoard(connectionState: .notFound))
-    ) {
+    #Preview("Not Found") {
         NavigationStack { ScanView() }
+            .mockBoard(connectionState: .notFound)
     }
-    #Preview(
-        "Connection Failed",
-        traits: .modifier(MockBoard(connectionState: .connectionFailed))
-    ) {
+    #Preview("Connection Failed") {
         NavigationStack { ScanView() }
+            .mockBoard(connectionState: .connectionFailed)
     }
-    #Preview(
-        "Setup Failed",
-        traits: .modifier(MockBoard(connectionState: .setupFailed))
-    ) {
+    #Preview("Setup Failed") {
         NavigationStack { ScanView() }
+            .mockBoard(connectionState: .setupFailed)
     }
-    #Preview(
-        "Powered Off",
-        traits: .modifier(MockBoard(connectionState: .poweredOff))
-    ) {
+    #Preview("Powered Off") {
         NavigationStack { ScanView() }
+            .mockBoard(connectionState: .poweredOff)
     }
 #endif


### PR DESCRIPTION
## Summary

Replaces the `MockBoard: PreviewModifier` struct with a simpler `View` extension method `.mockBoard(...)`. This reduces verbosity in all 15 `#Preview` blocks across the companion app by eliminating the `traits: .modifier(MockBoard(...))` pattern in favor of applying `.mockBoard(...)` directly on the preview content.

## Decisions & callouts

- `MockBoard` was a `PreviewModifier`, which is not a `ViewModifier` — so the replacement is a plain `View` extension rather than a `ViewModifier` conformance. This avoids the need for both a struct and a sugar extension.
- `NavigationStack` wrappers remain at each preview call site rather than being bundled into `.mockBoard()`, keeping view hierarchy concerns separate from environment injection.